### PR TITLE
Fix pallete history

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "cross-storage": "^1.0.0",
     "del": "^2.2.2",
     "dotenv": "^4.0.0",
-    "emojidex-client": "^0.15.0",
+    "emojidex-client": "^0.15.4",
     "eslint": "^3.15.0",
     "eslint-config-airbnb-base": "^11.1.0",
     "eslint-plugin-import": "^2.2.0",

--- a/spec/emojidexPalette.js
+++ b/spec/emojidexPalette.js
@@ -2,7 +2,7 @@ describe("emojidexPalette", function() {
   beforeAll(function(done) {
     clearStorage().then(() => {
       helperBefore();
-      let limitForSpec = 5;
+      let limitForSpec = 1;
       $("#palette-btn").emojidexPalette({
         paletteEmojisLimit: limitForSpec,
         onComplete: () => {

--- a/spec/emojidexPalette.js
+++ b/spec/emojidexPalette.js
@@ -169,9 +169,14 @@ describe("emojidexPalette", function() {
         properties: 'prop_innerHTML',
         watchChildren: true,
         callback(data, i, mutations) {
-          expect($(data.vals[0]).find('.favorite-pagination ul.pagination li.palette-num span').text().substr(0, 1)).toBe('2');
-          remove_watch($('#user-tab-content'), 'content_user_next');
-          done();
+          spec_timer({
+            time: 1000,
+            callback() {
+              expect($(data.vals[0]).find('.favorite-pagination ul.pagination li.palette-num span').text().substr(0, 1)).toBe('2');
+              remove_watch($('#user-tab-content'), 'content_user_next');
+              done();
+            }
+          });
         }
       });
 
@@ -185,9 +190,14 @@ describe("emojidexPalette", function() {
         properties: 'prop_innerHTML',
         watchChildren: true,
         callback(data, i, mutations) {
-          expect($(data.vals[0]).find('.favorite-pagination ul.pagination li.palette-num span').text().substr(0, 1)).toBe('1');
-          remove_watch($('#user-tab-content'), 'content_user_prev');
-          done();
+          spec_timer({
+            time: 1000,
+            callback() {
+              expect($(data.vals[0]).find('.favorite-pagination ul.pagination li.palette-num span').text().substr(0, 1)).toBe('1');
+              remove_watch($('#user-tab-content'), 'content_user_prev');
+              done();
+            }
+          });
         }
       });
       $('#tab-content-user-favorite').find('.pagination .palette-pager')[0].click();
@@ -218,9 +228,14 @@ describe("emojidexPalette", function() {
         properties: 'prop_innerHTML',
         watchChildren: true,
         callback(data, i, mutations) {
-          expect($(data.vals[0]).find('.history-pagination ul.pagination li.palette-num span').text().substr(0, 1)).toBe('2');
-          remove_watch($('#user-tab-content'), 'content_user_history_next');
-          done();
+          spec_timer({
+            time: 1000,
+            callback() {
+              expect($(data.vals[0]).find('.history-pagination ul.pagination li.palette-num span').text().substr(0, 1)).toBe('2');
+              remove_watch($('#user-tab-content'), 'content_user_history_next');
+              done();
+            }
+          });
         }
       });
 
@@ -234,9 +249,14 @@ describe("emojidexPalette", function() {
         properties: 'prop_innerHTML',
         watchChildren: true,
         callback(data, i, mutations) {
-          expect($(data.vals[0]).find('.history-pagination ul.pagination li.palette-num span').text().substr(0, 1)).toBe('1');
-          remove_watch($('#user-tab-content'), 'content_user_history_prev');
-          done();
+          spec_timer({
+            time: 1000,
+            callback() {
+              expect($(data.vals[0]).find('.history-pagination ul.pagination li.palette-num span').text().substr(0, 1)).toBe('1');
+              remove_watch($('#user-tab-content'), 'content_user_history_prev');
+              done();
+            }
+          });
         }
       });
 

--- a/src/es6/emojidexPalette/components/palette.js
+++ b/src/es6/emojidexPalette/components/palette.js
@@ -112,42 +112,6 @@ class Palette {
     return emoji_divs;
   }
 
-  setCodeList(kind, code_list) {
-    let emoji_divs = $(`<div class='${kind}-emoji-list clearfix'></div>`);
-    for (let i = 0; i < code_list.length; i++) {
-      let code = code_list[i];
-      let emoji_button = $('<button>',
-        {class: 'emoji-btn btn btn-default pull-left'});
-      let emoji_button_image = $('<img>', {
-        title: code,
-        class: 'img-responsive center-block',
-        src: `${this.EC.cdn_url}px32/${code.replace(/\s/g, '_')}.png`
-      }
-      );
-      emoji_button.prop('emoji_data', {code});
-
-      emoji_button.append(emoji_button_image);
-      emoji_button.click(e=> {
-        return this.insertEmojiAtCaret($(e.currentTarget).prop('emoji_data'));
-      }
-      );
-      //TODO implement ↓ properly
-      //@EC.Search.find code, (ret)=>
-      //  @setButtonInfo(ret, emoji_button)
-
-      emoji_divs.append(emoji_button);
-    }
-
-    return emoji_divs;
-  }
-
-  //TODO implement ↓ properly
-  //setButtonInfo: (emoji, target) ->
-  //  target.prop 'emoji_data', emoji
-  //  target.unbind('click')
-  //  target.click (e)=>
-  //    @insertEmojiAtCaret($(e.currentTarget).prop('emoji_data'))
-
   mojiOrCode(emoji) {
     if (emoji.moji !== null && emoji.moji !== '') { return emoji.moji; } else { return `:${emoji.code}:`; }
   }

--- a/src/es6/emojidexPalette/components/tabs/user_tabs/favorite_tab.js
+++ b/src/es6/emojidexPalette/components/tabs/user_tabs/favorite_tab.js
@@ -7,7 +7,7 @@ class FavoriteTab {
 
   createTabContent() {
     return this.EC.User.Favorites.get().then(response => {
-      return this.setFavoriteEmoji(response.emoji);
+      return this.setFavoriteEmoji(response);
     });
   }
 

--- a/src/es6/emojidexPalette/components/tabs/user_tabs/history_tab.js
+++ b/src/es6/emojidexPalette/components/tabs/user_tabs/history_tab.js
@@ -7,12 +7,12 @@ class HistoryTab {
 
   createTabContent() {
     return this.EC.User.History.get().then(response => {
-      return this.setHistoryEmoji(response.history.map((item) => item.emoji_code));
+      return this.setHistoryEmoji(response);
     });
   }
 
   setHistoryEmoji(history) {
-    this.tab_pane.append(this.palette.setCodeList('history', history));
+    this.tab_pane.append(this.palette.setEmojiList('history', history));
     return this.createPagination()
   }
 

--- a/src/es6/emojidexPalette/components/tabs/user_tabs/history_tab.js
+++ b/src/es6/emojidexPalette/components/tabs/user_tabs/history_tab.js
@@ -26,7 +26,7 @@ class HistoryTab {
 
     let callback = response => {
       this.tab_pane.children().remove();
-      this.tab_pane.append(this.setHistoryEmoji(response.map((item) => item.emoji_code)));
+      this.tab_pane.append(this.setHistoryEmoji(response));
     }
     let prev_func = () => this.EC.User.History.prev(callback);
     let next_func = () => this.EC.User.History.next(callback);


### PR DESCRIPTION
## 何でこの変更が必要なの？
今までhistoryのgetで絵文字データが返ってこなくてhistoryタブの絵文字ボタンからの入力がバグっていたため、APIの修正に合わせてこちらも修正した。

## このPRでやった事は何？
- emojidex-clientのバージョンアップ
- emojidex-clientからの戻り値が変わったためfavorite/historyともにgetを修正
- 不要になったメソッドの削除
- 手動ではきちんと動くのに、favorite/historyタブともにページ移動のspecが失敗しやすいのでタイマーを導入

## このPRで確認した事は何？
- [x] specがオールグリーン
