### PR TITLE
Add follow feature to pallet

### DIFF
--- a/spec/emojidexPalette.js
+++ b/spec/emojidexPalette.js
@@ -30,7 +30,7 @@ describe("emojidexPalette", function() {
       properties: 'display',
       callback() {
         expect($('.ui-dialog')).toHaveCss({display: 'block'});
-        remove_watch($('.ui-dialog'), 'dialog');
+        removeWatch($('.ui-dialog'), 'dialog');
         done();
       }
     });
@@ -49,7 +49,7 @@ describe("emojidexPalette", function() {
         callback(data, i) {
           if (data.vals[0].match(/category-emoji-list/)) {
             expect($('#tab-content-faces').find('img').length).toBeTruthy();
-            remove_watch($('#tab-content-faces'), 'content_faces');
+            removeWatch($('#tab-content-faces'), 'content_faces');
             done();
           }
         }
@@ -67,7 +67,7 @@ describe("emojidexPalette", function() {
         watchChildren: true,
         callback(data, i, mutations) {
           expect($(data.vals[0]).find('ul.pagination li.disabled span').text().substr(0, 1)).toBe('2');
-          remove_watch($('#tab-content-faces'), 'content_faces');
+          removeWatch($('#tab-content-faces'), 'content_faces');
           done();
         }
       });
@@ -82,7 +82,7 @@ describe("emojidexPalette", function() {
         watchChildren: true,
         callback(data, i, mutations) {
           expect($(data.vals[0]).find('ul.pagination li.palette-num span').text().substr(0, 1)).toBe('1');
-          remove_watch($('#tab-content-faces'), 'content_faces');
+          removeWatch($('#tab-content-faces'), 'content_faces');
           done();
         }
       });
@@ -105,7 +105,7 @@ describe("emojidexPalette", function() {
       callback(data, i) {
         if (data.vals[0].match(/search-emoji-list/)) {
           expect($($('#tab-content-search').find('img')[0]).attr('title')).toContain('test');
-          remove_watch($('#tab-content-search'), 'content_search');
+          removeWatch($('#tab-content-search'), 'content_search');
           done();
         }
       }
@@ -127,7 +127,7 @@ describe("emojidexPalette", function() {
           if (data.vals[0].match(/login-error/)) {
             // TODO: english text
             expect($('#login-error span').text()).toBe('Login failed. Please check your username and password or login here.');
-            remove_watch($('#tab-content-user'), 'content_user');
+            removeWatch($('#tab-content-user'), 'content_user');
             done();
           }
         }
@@ -150,7 +150,7 @@ describe("emojidexPalette", function() {
           if (data.vals[0].match(/favorite-emoji-list/)) {
             $('#tab-user-favorite a').click();
             expect($('#tab-content-user-favorite').find('img').length).toBeTruthy();
-            remove_watch($('#tab-content-user'), 'content_user');
+            removeWatch($('#tab-content-user'), 'content_user');
             done();
           }
         }
@@ -173,7 +173,7 @@ describe("emojidexPalette", function() {
             time: 1000,
             callback() {
               expect($(data.vals[0]).find('.favorite-pagination ul.pagination li.palette-num span').text().substr(0, 1)).toBe('2');
-              remove_watch($('#user-tab-content'), 'content_user_next');
+              removeWatch($('#user-tab-content'), 'content_user_next');
               done();
             }
           });
@@ -194,7 +194,7 @@ describe("emojidexPalette", function() {
             time: 1000,
             callback() {
               expect($(data.vals[0]).find('.favorite-pagination ul.pagination li.palette-num span').text().substr(0, 1)).toBe('1');
-              remove_watch($('#user-tab-content'), 'content_user_prev');
+              removeWatch($('#user-tab-content'), 'content_user_prev');
               done();
             }
           });
@@ -212,7 +212,7 @@ describe("emojidexPalette", function() {
         callback(data, i) {
           if (data.vals[0].match(/history-emoji-list/)) {
             expect($('#tab-content-user-history').find('img').length).toBeTruthy();
-            remove_watch($('#tab-content-user'), 'content_user_history');
+            removeWatch($('#tab-content-user'), 'content_user_history');
             done();
           }
         }
@@ -232,7 +232,7 @@ describe("emojidexPalette", function() {
             time: 1000,
             callback() {
               expect($(data.vals[0]).find('.history-pagination ul.pagination li.palette-num span').text().substr(0, 1)).toBe('2');
-              remove_watch($('#user-tab-content'), 'content_user_history_next');
+              removeWatch($('#user-tab-content'), 'content_user_history_next');
               done();
             }
           });
@@ -253,7 +253,7 @@ describe("emojidexPalette", function() {
             time: 1000,
             callback() {
               expect($(data.vals[0]).find('.history-pagination ul.pagination li.palette-num span').text().substr(0, 1)).toBe('1');
-              remove_watch($('#user-tab-content'), 'content_user_history_prev');
+              removeWatch($('#user-tab-content'), 'content_user_history_prev');
               done();
             }
           });
@@ -283,7 +283,7 @@ describe("emojidexPalette", function() {
         watchChildren: true,
         callback(data, i) {
           expect($('#palette-emoji-username-input')).toHaveCss({display: 'block'});
-          remove_watch($('#tab-content-user'), 'content_user');
+          removeWatch($('#tab-content-user'), 'content_user');
           done();
         }
       });
@@ -299,7 +299,7 @@ describe("emojidexPalette", function() {
         callback(data, i) {
           if (data.vals[0].match(/favorite-emoji-list/)) {
             expect($('#tab-content-user-favorite').find('img').length).toBeTruthy();
-            remove_watch($('#tab-content-user'), 'content_user');
+            removeWatch($('#tab-content-user'), 'content_user');
             done();
           }
         }
@@ -342,7 +342,7 @@ describe("emojidexPalette", function() {
               id: 'dialog_2',
               properties: 'display',
               callback() {
-                remove_watch($('.ui-dialog'), 'dialog_2');
+                removeWatch($('.ui-dialog'), 'dialog_2');
 
                 $('#tab-content-user').watch({
                   id: 'content_user',
@@ -352,7 +352,7 @@ describe("emojidexPalette", function() {
                     if (data.vals[0].match(/favorite-emoji-list/)) {
                       expect($('#tab-content-user-favorite').find('img').length).toBeTruthy();
                       $('button.pull-right[aria-label="Close"]').click();
-                      remove_watch($('#tab-content-user'), 'content_user');
+                      removeWatch($('#tab-content-user'), 'content_user');
                       return done();
                     }
                   }

--- a/spec/emojidexPalette.js
+++ b/spec/emojidexPalette.js
@@ -328,6 +328,71 @@ describe("emojidexPalette", function() {
       $($(`${selectorCurrentUserInfo} .palette-pager`)[0]).click();
     });
 
+    // followers tab --------
+    it('show followers tab [Requires a premium user account and followers user]', function(done) {
+      if (typeof user_info === 'undefined' || user_info === null) { pending(); }
+      $('#follow-followers').watch({
+        id: "watcher",
+        properties: 'attr_class',
+        callback(data, i) {
+          expect($('#follow-followers .users .btn').length).toBeTruthy();
+          removeWatch($('#follow-followers'), 'watcher');
+          done();
+        }
+      });
+
+      $('#tab-user-followers a').click();
+    });
+
+    it('show followers user info [Requires a premium user account and followers user]', function(done) {
+      if (typeof user_info === 'undefined' || user_info === null) { pending(); }
+      $('#follow-followers .user-info').watch({
+        id: "watcher",
+        properties: 'attr_class',
+        callback(data, i) {
+          expect($('#follow-followers .user-info.on .emoji-btn').length).toBeTruthy();
+          removeWatch($('.user-info'), 'watcher');
+          done();
+        }
+      });
+
+      $($('#follow-followers .users .btn')[0]).click();
+    });
+
+    it('show followers user emoji next [Requires premium a user account and followers user]', function(done) {
+      if (typeof user_info === 'undefined' || user_info === null) { pending(); }
+      const selectorCurrentUserInfo= '#follow-followers .user-info.on';
+      $(selectorCurrentUserInfo).watch({
+        id: "watcher",
+        properties: 'prop_innerHTML',
+        watchChildren: true,
+        callback(data, i) {
+          expect($(`${selectorCurrentUserInfo} .palette-num span`).text().charAt(0)).toBe('2');
+          removeWatch($('.user-info'), 'watcher');
+          done();
+        }
+      });
+
+      $($(`${selectorCurrentUserInfo} .palette-pager`)[1]).click();
+    });
+
+    it('show followers user emoji previous [Requires a premium user account and followers user]', function(done) {
+      if (typeof user_info === 'undefined' || user_info === null) { pending(); }
+      const selectorCurrentUserInfo= '#follow-followers .user-info.on';
+      $(selectorCurrentUserInfo).watch({
+        id: "watcher",
+        properties: 'prop_innerHTML',
+        watchChildren: true,
+        callback(data, i) {
+          expect($(`${selectorCurrentUserInfo} .palette-num span`).text().charAt(0)).toBe('1');
+          removeWatch($('.user-info'), 'watcher');
+          done();
+        }
+      });
+
+      $($(`${selectorCurrentUserInfo} .palette-pager`)[0]).click();
+    });
+
    // it 'premium user can see the newest/popular emoji', (done) ->
    //   pending() unless premium_user_info?
    //   timer_option =

--- a/spec/emojidexPalette.js
+++ b/spec/emojidexPalette.js
@@ -296,7 +296,7 @@ describe("emojidexPalette", function() {
 
     it('show following user emoji next [Requires a user account and following user]', function(done) {
       if (typeof user_info === 'undefined' || user_info === null) { pending(); }
-      const selectorCurrentUserInfo= '#follow-following .user-info.on';
+      const selectorCurrentUserInfo = '#follow-following .user-info.on';
       $(selectorCurrentUserInfo).watch({
         id: "watcher",
         properties: 'prop_innerHTML',
@@ -313,7 +313,7 @@ describe("emojidexPalette", function() {
 
     it('show following user emoji previous [Requires a user account and following user]', function(done) {
       if (typeof user_info === 'undefined' || user_info === null) { pending(); }
-      const selectorCurrentUserInfo= '#follow-following .user-info.on';
+      const selectorCurrentUserInfo = '#follow-following .user-info.on';
       $(selectorCurrentUserInfo).watch({
         id: "watcher",
         properties: 'prop_innerHTML',
@@ -361,7 +361,7 @@ describe("emojidexPalette", function() {
 
     it('show followers user emoji next [Requires premium a user account and followers user]', function(done) {
       if (typeof user_info === 'undefined' || user_info === null) { pending(); }
-      const selectorCurrentUserInfo= '#follow-followers .user-info.on';
+      const selectorCurrentUserInfo = '#follow-followers .user-info.on';
       $(selectorCurrentUserInfo).watch({
         id: "watcher",
         properties: 'prop_innerHTML',
@@ -378,7 +378,7 @@ describe("emojidexPalette", function() {
 
     it('show followers user emoji previous [Requires a premium user account and followers user]', function(done) {
       if (typeof user_info === 'undefined' || user_info === null) { pending(); }
-      const selectorCurrentUserInfo= '#follow-followers .user-info.on';
+      const selectorCurrentUserInfo = '#follow-followers .user-info.on';
       $(selectorCurrentUserInfo).watch({
         id: "watcher",
         properties: 'prop_innerHTML',

--- a/spec/emojidexPalette.js
+++ b/spec/emojidexPalette.js
@@ -263,6 +263,71 @@ describe("emojidexPalette", function() {
       $('#tab-content-user-history').find('.pagination .palette-pager')[0].click();
     });
 
+    // following tab --------
+    it('show following tab [Requires a user account and following user]', function(done) {
+      if (typeof user_info === 'undefined' || user_info === null) { pending(); }
+      $('#follow-following').watch({
+        id: "watcher",
+        properties: 'attr_class',
+        callback(data, i) {
+          expect($('#follow-following .users .btn').length).toBeTruthy();
+          removeWatch($('#follow-following'), 'watcher');
+          done();
+        }
+      });
+
+      $('#tab-user-following a').click();
+    });
+
+    it('show following user info [Requires a user account and following user]', function(done) {
+      if (typeof user_info === 'undefined' || user_info === null) { pending(); }
+      $('#follow-following .user-info').watch({
+        id: "watcher",
+        properties: 'attr_class',
+        callback(data, i) {
+          expect($('#follow-following .user-info.on .emoji-btn').length).toBeTruthy();
+          removeWatch($('.user-info'), 'watcher');
+          done();
+        }
+      });
+
+      $($('#follow-following .users .btn')[0]).click();
+    });
+
+    it('show following user emoji next [Requires a user account and following user]', function(done) {
+      if (typeof user_info === 'undefined' || user_info === null) { pending(); }
+      const selectorCurrentUserInfo= '#follow-following .user-info.on';
+      $(selectorCurrentUserInfo).watch({
+        id: "watcher",
+        properties: 'prop_innerHTML',
+        watchChildren: true,
+        callback(data, i) {
+          expect($(`${selectorCurrentUserInfo} .palette-num span`).text().charAt(0)).toBe('2');
+          removeWatch($('.user-info'), 'watcher');
+          done();
+        }
+      });
+
+      $($(`${selectorCurrentUserInfo} .palette-pager`)[1]).click();
+    });
+
+    it('show following user emoji previous [Requires a user account and following user]', function(done) {
+      if (typeof user_info === 'undefined' || user_info === null) { pending(); }
+      const selectorCurrentUserInfo= '#follow-following .user-info.on';
+      $(selectorCurrentUserInfo).watch({
+        id: "watcher",
+        properties: 'prop_innerHTML',
+        watchChildren: true,
+        callback(data, i) {
+          expect($(`${selectorCurrentUserInfo} .palette-num span`).text().charAt(0)).toBe('1');
+          removeWatch($('.user-info'), 'watcher');
+          done();
+        }
+      });
+
+      $($(`${selectorCurrentUserInfo} .palette-pager`)[0]).click();
+    });
+
    // it 'premium user can see the newest/popular emoji', (done) ->
    //   pending() unless premium_user_info?
    //   timer_option =

--- a/spec/helpers/method.js
+++ b/spec/helpers/method.js
@@ -23,7 +23,7 @@ function spec_timer(option) {
   if (default_option.callback != null) { return setTimeout(default_option.callback, default_option.time); }
 }
 
-function remove_watch(object, id) {
+function removeWatch(object, id) {
   object.unwatch(id);
   object.removeData(id);
 }

--- a/src/es6/emojidexPalette/components/tabs/user_tab.js
+++ b/src/es6/emojidexPalette/components/tabs/user_tab.js
@@ -6,6 +6,7 @@ class UserTab {
     this.historyTab = new HistoryTab(this);
     this.favoriteTab = new FavoriteTab(this);
     this.followingTab = new FollowingTab(this);
+    this.followersTab = new FollowersTab(this);
   }
 
   getTabContent() {
@@ -45,10 +46,13 @@ class UserTab {
     let callback = auth_info => {
       if (auth_info.status === 'verified') {
         this.hideLoginForm();
-        this.setUserTab();
+        this.setUserTab(auth_info);
         this.setHistoryTab();
         this.setFavoriteTab();
         this.setFollowingTab();
+        if(auth_info.premium) {
+          this.setFollowersTab();
+        }
         return this.palette.toggleSorting();
       } else {
         return this.showError(auth_info);
@@ -81,11 +85,14 @@ class UserTab {
     return $('#palette-emoji-login-submit').show();
   }
 
-  setUserTab() {
+  setUserTab(auth_info) {
     let user_tab_list = $('<ul class="nav nav-tabs mb-m mt-m" id="user-tab-list"></ul>');
     user_tab_list.append($('<li id="tab-user-favorite" class="active"><a href="#tab-content-user-favorite" data-toggle="tab">Favorite</a></li>'));
     user_tab_list.append($('<li id="tab-user-history"><a href="#tab-content-user-history" data-toggle="tab">History</a></li>'));
-    user_tab_list.append($('<li id="tab-user-Following"><a href="#follow-following" data-toggle="tab">Following</a></li>'));
+    user_tab_list.append($('<li id="tab-user-following"><a href="#follow-following" data-toggle="tab">Following</a></li>'));
+    if(auth_info.premium) {
+      user_tab_list.append($('<li id="tab-user-followers"><a href="#follow-followers" data-toggle="tab">Followers</a></li>'));
+    }
 
     let logout_btn = $('<button class="btn btn-default btm-sm pull-right" id="palette-emoji-logout">LogOut</button>');
     logout_btn.click(() => {
@@ -120,7 +127,12 @@ class UserTab {
 
   setFollowingTab() {
     this.user_tab_content.append(this.followingTab.tab_pane);
-    this.followingTab.addClickEvents();
+    this.followingTab.init();
+  }
+
+  setFollowersTab() {
+    this.user_tab_content.append(this.followersTab.tab_pane);
+    this.followersTab.init();
   }
 
   setPremiumData(response, kind) {

--- a/src/es6/emojidexPalette/components/tabs/user_tabs/followers_tab.js
+++ b/src/es6/emojidexPalette/components/tabs/user_tabs/followers_tab.js
@@ -6,11 +6,11 @@ class FollowersTab {
     this.selector_tab_pane = '#emojidex-emoji-palette #follow-followers';
     this.selector_users = `${this.selector_tab_pane} > .users`;
 
-    this.tab_pane = $(
-      `<div id='follow-followers' class='tab-pane'>
+    this.tab_pane = $(`
+      <div id='follow-followers' class='tab-pane'>
         <div class='users'></div>
-      </div>`
-    )
+      </div>
+    `)
   }
 
   init() {

--- a/src/es6/emojidexPalette/components/tabs/user_tabs/followers_tab.js
+++ b/src/es6/emojidexPalette/components/tabs/user_tabs/followers_tab.js
@@ -1,0 +1,90 @@
+class FollowersTab {
+  constructor(user_tab) {
+    this.EC = user_tab.palette.EC;
+    this.palette = user_tab.palette;
+
+    this.selector_tab_pane = '#emojidex-emoji-palette #follow-followers';
+    this.selector_users = `${this.selector_tab_pane} > .users`;
+
+    this.tab_pane = $(
+      `<div id='follow-followers' class='tab-pane'>
+        <div class='users'></div>
+      </div>`
+    )
+  }
+
+  init() {
+    $(this.selector_users).children().remove();
+    $(`${this.selector_tab_pane} > .user-info`).remove();
+
+    this.EC.User.Follow.getFollowers(followers => {
+      for(let user_name of followers) {
+        this.setUserButton(user_name);
+        this.setUserInfo(user_name);
+      }
+    })
+  }
+
+  setUserButton(user_name) {
+    let user_button = $(`<div class='btn btn-default'>${user_name}</div>`).click(e => {
+      $(this.selector_tab_pane).find(`#${$(e.currentTarget).text()}`).addClass('on')
+    })
+    $(this.selector_users).append(user_button);
+  }
+
+  setUserInfo(user_name) {
+    let user_info = $(`
+      <div id='${user_name}' class='user-info'>
+        <div class='btn-close' aria-hidden='true'><i class='emjdx-abstract flip-vertical'></i></div>
+        <div class='user-name'>${user_name}</div>
+        <div class="clearfix"/>
+        <hr>
+        <div class="user-emoji-list clearfix">
+        </div>
+      </div>
+    `).click(e => {
+      e.stopPropagation();
+    })
+    user_info.find('.btn-close').click(() => {
+      $(this.selector_tab_pane).find('*').removeClass('on');
+    });
+    $(this.selector_tab_pane).append(user_info);
+
+    this.setUserEmojisInfo(user_info)
+  }
+
+  setUserEmojisInfo(user_info, option = {}) {
+    const user_name = user_info.attr('id')
+    return this.EC.Indexes.user(user_name, undefined, option).then((response) => {
+      user_info.data(response.meta);
+      user_info.data({user_name: user_name, max_page: Math.ceil(response.meta.total_count / this.EC.limit ? response.meta.total_count / this.EC.limit : 1)});
+
+      user_info.find('.user-emoji-list').children().remove()
+      user_info.find('.followers-pagination').remove()
+
+      user_info.find('.user-emoji-list').append(this.palette.setEmojiList('followers', response.emoji))
+      this.setPagination(user_info)
+    })
+  }
+
+  setPagination(user_info) {
+    let meta = user_info.data();
+    if (!this.EC.User.auth_info.premium) {
+      meta.max_page = 1;
+    }
+
+    const prev_func = () => {
+      option = {page: meta.page - 1};
+      if(option.page > 0) {
+        this.setUserEmojisInfo(user_info, option);
+      }
+    }
+    const next_func = () => {
+      option = {page: meta.page + 1};
+      if(option.page <= meta.max_page) {
+        this.setUserEmojisInfo(user_info, option);
+      }
+    }
+    user_info.append(this.palette.getPagination('followers', prev_func, next_func, meta.page, meta.max_page))
+  }
+}

--- a/src/es6/emojidexPalette/components/tabs/user_tabs/followers_tab.js
+++ b/src/es6/emojidexPalette/components/tabs/user_tabs/followers_tab.js
@@ -10,7 +10,7 @@ class FollowersTab {
       <div id='follow-followers' class='tab-pane'>
         <div class='users'></div>
       </div>
-    `)
+    `);
   }
 
   init() {
@@ -22,13 +22,13 @@ class FollowersTab {
         this.setUserButton(user_name);
         this.setUserInfo(user_name);
       }
-    })
+    });
   }
 
   setUserButton(user_name) {
     let user_button = $(`<div class='btn btn-default'>${user_name}</div>`).click(e => {
-      $(this.selector_tab_pane).find(`#${$(e.currentTarget).text()}`).addClass('on')
-    })
+      $(this.selector_tab_pane).find(`#${$(e.currentTarget).text()}`).addClass('on');
+    });
     $(this.selector_users).append(user_button);
   }
 
@@ -44,27 +44,27 @@ class FollowersTab {
       </div>
     `).click(e => {
       e.stopPropagation();
-    })
+    });
     user_info.find('.btn-close').click(() => {
       $(this.selector_tab_pane).find('*').removeClass('on');
     });
     $(this.selector_tab_pane).append(user_info);
 
-    this.setUserEmojisInfo(user_info)
+    this.setUserEmojisInfo(user_info);
   }
 
   setUserEmojisInfo(user_info, option = {}) {
-    const user_name = user_info.attr('id')
+    const user_name = user_info.attr('id');
     return this.EC.Indexes.user(user_name, undefined, option).then((response) => {
       user_info.data(response.meta);
       user_info.data({user_name: user_name, max_page: Math.ceil(response.meta.total_count / this.EC.limit ? response.meta.total_count / this.EC.limit : 1)});
 
-      user_info.find('.user-emoji-list').children().remove()
-      user_info.find('.followers-pagination').remove()
+      user_info.find('.user-emoji-list').children().remove();
+      user_info.find('.followers-pagination').remove();
 
-      user_info.find('.user-emoji-list').append(this.palette.setEmojiList('followers', response.emoji))
-      this.setPagination(user_info)
-    })
+      user_info.find('.user-emoji-list').append(this.palette.setEmojiList('followers', response.emoji));
+      this.setPagination(user_info);
+    });
   }
 
   setPagination(user_info) {
@@ -85,6 +85,6 @@ class FollowersTab {
         this.setUserEmojisInfo(user_info, option);
       }
     }
-    user_info.append(this.palette.getPagination('followers', prev_func, next_func, meta.page, meta.max_page))
+    user_info.append(this.palette.getPagination('followers', prev_func, next_func, meta.page, meta.max_page));
   }
 }

--- a/src/es6/emojidexPalette/components/tabs/user_tabs/following_tab.js
+++ b/src/es6/emojidexPalette/components/tabs/user_tabs/following_tab.js
@@ -10,7 +10,7 @@ class FollowingTab {
       <div id='follow-following' class='tab-pane'>
         <div class='users'></div>
       </div>
-    `)
+    `);
   }
 
   init() {
@@ -22,13 +22,13 @@ class FollowingTab {
         this.setUserButton(user_name);
         this.setUserInfo(user_name);
       }
-    })
+    });
   }
 
   setUserButton(user_name) {
     let user_button = $(`<div class='btn btn-default'>${user_name}</div>`).click(e => {
-      $(this.selector_tab_pane).find(`#${$(e.currentTarget).text()}`).addClass('on')
-    })
+      $(this.selector_tab_pane).find(`#${$(e.currentTarget).text()}`).addClass('on');
+    });
     $(this.selector_users).append(user_button);
   }
 
@@ -44,27 +44,27 @@ class FollowingTab {
       </div>
     `).click(e => {
       e.stopPropagation();
-    })
+    });
     user_info.find('.btn-close').click(() => {
       $(this.selector_tab_pane).find('*').removeClass('on');
     });
     $(this.selector_tab_pane).append(user_info);
 
-    this.setUserEmojisInfo(user_info)
+    this.setUserEmojisInfo(user_info);
   }
 
   setUserEmojisInfo(user_info, option = {}) {
-    const user_name = user_info.attr('id')
+    const user_name = user_info.attr('id');
     return this.EC.Indexes.user(user_name, undefined, option).then((response) => {
       user_info.data(response.meta);
       user_info.data({user_name: user_name, max_page: Math.ceil(response.meta.total_count / this.EC.limit ? response.meta.total_count / this.EC.limit : 1)});
 
-      user_info.find('.user-emoji-list').children().remove()
-      user_info.find('.following-pagination').remove()
+      user_info.find('.user-emoji-list').children().remove();
+      user_info.find('.following-pagination').remove();
 
-      user_info.find('.user-emoji-list').append(this.palette.setEmojiList('following', response.emoji))
-      this.setPagination(user_info)
-    })
+      user_info.find('.user-emoji-list').append(this.palette.setEmojiList('following', response.emoji));
+      this.setPagination(user_info);
+    });
   }
 
   setPagination(user_info) {
@@ -85,6 +85,6 @@ class FollowingTab {
         this.setUserEmojisInfo(user_info, option);
       }
     }
-    user_info.append(this.palette.getPagination('following', prev_func, next_func, meta.page, meta.max_page))
+    user_info.append(this.palette.getPagination('following', prev_func, next_func, meta.page, meta.max_page));
   }
 }

--- a/src/es6/emojidexPalette/components/tabs/user_tabs/following_tab.js
+++ b/src/es6/emojidexPalette/components/tabs/user_tabs/following_tab.js
@@ -6,11 +6,11 @@ class FollowingTab {
     this.selector_tab_pane = '#emojidex-emoji-palette #follow-following';
     this.selector_users = `${this.selector_tab_pane} > .users`;
 
-    this.tab_pane = $(
-      `<div id='follow-following' class='tab-pane'>
+    this.tab_pane = $(`
+      <div id='follow-following' class='tab-pane'>
         <div class='users'></div>
-      </div>`
-    )
+      </div>
+    `)
   }
 
   init() {

--- a/src/sass/_emoji_palette.scss
+++ b/src/sass/_emoji_palette.scss
@@ -175,41 +175,55 @@
   }
 }
 
-#follow-following {
-  .wrapper {
-    background-color: rgba(0, 0, 0, 0.5);
-    position: absolute;
-    bottom: 0px;
-    width: 100%;
-    height: 254px;
-    left: 0;
-    display: none;
+#follow-following, #follow-followers {
+  .users {
+    .btn {
+      margin: 2px;
+    }
+  }
 
-    &.on {
-      display: flex;
+  .user-info {
+    position: relative;
+    background-color: rgba(255, 255, 255, 1);
+    margin-top: -36px;
+    display: none;
+    width: 100%;
+    height: 327px;
+    border-radius: 4px;
+
+    .user-name {
+      float: left;
+      line-height: 22px;
+      margin-left: 8px;
+      padding-left: 12px;
+      border-left: 1px #ddd solid;
     }
 
-    .user-info {
-      background-color: rgba(255, 255, 255, 1);
-      margin: auto;
-      padding: 10px;
-      display: none;
-      width: 90%;
-      height: 75%;
-      border-radius: 4px;
-
-      .user-name {
-        float: left;
+    .btn-close {
+      -ms-filter: "progid:DXImageTransform.Microsoft.BasicImage(rotation=2, mirror=1)";
+      -webkit-transform: scale(-1, 1);
+      -ms-transform: scale(-1, 1);
+      transform: scale(-1, 1);
+      float: left;
+      cursor: pointer;
+      i {
+        color: #ddd;
+        font-size: 20px;
+        line-height: 20px;
       }
-
-      .btn-close {
-        float: right;
-        cursor: pointer;
+      &:hover {
+        i {
+          color: #bbb;
+        }
       }
+    }
 
-      &.on {
-        display: block;
-      }
+    .pagination-container {
+      bottom: 0px;
+    }
+
+    &.on {
+      display: block;
     }
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1264,9 +1264,9 @@ ee-first@1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/ee-first/-/ee-first-1.1.1.tgz#590c61156b0ae2f4f0255732a158b266bc56b21d"
 
-emojidex-client@^0.15.0:
-  version "0.15.2"
-  resolved "https://registry.yarnpkg.com/emojidex-client/-/emojidex-client-0.15.2.tgz#faa83cf00d3f80462854f1d94402f143c7878a0c"
+emojidex-client@^0.15.4:
+  version "0.15.5"
+  resolved "https://registry.yarnpkg.com/emojidex-client/-/emojidex-client-0.15.5.tgz#0b18366cbe6a4a25c77dbf85e00ea1f66b48af66"
 
 emojis-list@^2.0.0:
   version "2.1.0"


### PR DESCRIPTION
## 何でこの変更が必要なの？
<!-- [必須] 必要な理由の詳細を、なるべく分り易く書いて下さい -->
clientに追加されたフォロー機能をパレットに実装するため。
https://github.com/emojidex/emojidex-web/pull/41 で作ったモックを元に、clientの機能を使って実装した。

スクリーンショット：
![image](https://user-images.githubusercontent.com/1257122/27848649-ad8e8f0e-6181-11e7-850c-bfd0602bd529.png)

## このPRでやった事は何？
<!-- [必須] リストを使った箇条書きで書いて下さい -->
- パレットのユーザータブにfollowing、followersタブを追加
  - モックで作ったスタイルを修正
- specのヘルパーメソッドの名前を修正
- following、followersタブのspecを追加
- emojidex-clientのパッケージを更新

## このPRではやらない事にした変更ってあった？
<!-- 「やらない事にした変更: 理由」の書式で、リストを使った箇条書きで書いて下さい -->
- specの全体的な更新: 分割するタスクが終わってからやっていきたいから
- following、followersタブの共通をまとめる事: 他の所も似た様な箇所があるので、まとめて別タスクでやりたいから

## このPRで確認した事は何？
<!-- [必須] 下記以外に何か確認した事があれば、同じくチェック付きのリストで追記して下さい -->
- [x] specがオールグリーン
