### PR TITLE
Refactor spec

### DIFF
--- a/gulpfile.babel.js
+++ b/gulpfile.babel.js
@@ -273,9 +273,9 @@ gulp.task('jasmine', () => {
     'dist/img/logo.png',
     'dist/css/document.min.css',
     'dist/css/emojidex.min.css',
+    'spec/emojidexAutocomplete.js',
     'spec/palette/user_login.js',
     'spec/palette/*.js',
-    'spec/emojidexAutocomplete.js',
     'spec/emojidexReplace.js'
   ];
   return gulp.src(testFiles)

--- a/spec/emojidexAutocomplete.js
+++ b/spec/emojidexAutocomplete.js
@@ -1,26 +1,23 @@
-describe("emojidexAutocomplete", function() {
+describe("emojidexAutocomplete", () => {
   beforeAll(() => helperBefore());
 
   afterAll(() => helperAfter());
 
-  it('show autocomplete view (If this spec failed, test in browser.)', function(done) {
+  it('show autocomplete view (If this spec failed, test in browser.)', done => {
     let plain_text = $('.emojidex-plain_text').emojidexAutocomplete({
       onComplete: () => {
         expect($('.textcomplete-dropdown').length).toEqual(0);
 
         simulateTypingIn(plain_text);
-        spec_timer({
-          time: 3000,
-          callback() {
-            expect($('.textcomplete-dropdown').css('display')).toEqual('block');
-            done();
-          }
+        specTimer(3000).then(() => {
+          expect($('.textcomplete-dropdown').css('display')).toEqual('block');
+          done();
         });
       }
     });
   });
 
-  it('inserts a text emoji code in an element marked as emojidex-plain_text', function() {
+  it('inserts a text emoji code in an element marked as emojidex-plain_text', () => {
     let target = $('.textcomplete-dropdown li a')[0];
     let text = `:${$(target).text().trim()}:`;
     simulateMouseEvent(target);
@@ -29,24 +26,20 @@ describe("emojidexAutocomplete", function() {
     $('.textcomplete-dropdown').remove();
   });
 
-  it('inserts an emoji image in an element marked as emojidex-content_editable', function(done) {
+  it('inserts an emoji image in an element marked as emojidex-content_editable', done => {
     let content_editable = $('.emojidex-content_editable').emojidexAutocomplete({
       onComplete: () => {
         simulateTypingIn(content_editable);
-        spec_timer({
-          time: 3000,
-          callback() {
-            let target = $('.textcomplete-dropdown li a')[0];
-            let text = `${$(target).text().trim()}.png`;
-            simulateMouseEvent(target);
+        specTimer(3000).then(() => {
+          let target = $('.textcomplete-dropdown li a')[0];
+          let text = `${$(target).text().trim()}.png`;
+          simulateMouseEvent(target);
 
-            let src = content_editable.find('img').attr('src').split('/');
-            expect(src[src.length - 1]).toBe(text);
-            done();
-          }
+          let src = content_editable.find('img').attr('src').split('/');
+          expect(src[src.length - 1]).toBe(text);
+          done();
         });
       }
     });
   });
-}
-);
+});

--- a/spec/helpers/method.js
+++ b/spec/helpers/method.js
@@ -13,16 +13,6 @@ function helperAfter() {
   $('#spec-wrap').remove();
 }
 
-function spec_timer(option) {
-  let default_option = {
-    time: 100,
-    callback: undefined
-  };
-  $.extend(default_option, option);
-
-  if (default_option.callback != null) { return setTimeout(default_option.callback, default_option.time); }
-}
-
 function specTimer(time) {
   return new Promise((resolve, reject) => {
     setTimeout(resolve, time);

--- a/spec/helpers/method.js
+++ b/spec/helpers/method.js
@@ -66,3 +66,39 @@ function closePalette() {
   $('button.pull-right[aria-label="Close"]').click();
   $('#emojidex-emoji-palette').remove();
 }
+
+function showPalette(callback) {
+  $('.ui-dialog').watch({
+    id: 'dialog',
+    properties: 'display',
+    callback() {
+      removeWatch($('.ui-dialog'), 'dialog');
+      callback();
+    }
+  });
+  specTimer(1000).then(() => {
+    $('.emojidex-palette-button')[0].click();
+  });
+}
+
+function preparePaletteButtons(done) {
+  let limitForSpec = 1;
+  $("#palette-btn").emojidexPalette({
+    paletteEmojisLimit: limitForSpec,
+    onComplete: () => {
+      $("#palette-input").emojidexPalette({
+        paletteEmojisLimit: limitForSpec,
+        onComplete: () => { done(); }
+      });
+    }
+  });
+}
+
+function loginUser(user, password) {
+  specTimer(1000).then(() => {
+    $('#tab-user a').click();
+    $('#palette-emoji-username-input').val(user);
+    $('#palette-emoji-password-input').val(password);
+    $('#palette-emoji-login-submit').click();
+  });
+}

--- a/spec/palette/base.js
+++ b/spec/palette/base.js
@@ -2,16 +2,7 @@ describe("emojidexPalette:Base", () => {
   beforeAll(done => {
     clearStorage().then(() => {
       helperBefore();
-      let limitForSpec = 1;
-      $("#palette-btn").emojidexPalette({
-        paletteEmojisLimit: limitForSpec,
-        onComplete: () => {
-          $("#palette-input").emojidexPalette({
-            paletteEmojisLimit: limitForSpec,
-            onComplete: () => { done(); }
-          });
-        }
-      });
+      preparePaletteButtons(done);
     });
   });
 
@@ -25,18 +16,10 @@ describe("emojidexPalette:Base", () => {
   it("show emojidexPalette", done => {
     expect($('.ui-dialog')).toHaveCss({display: 'none'});
 
-    $('.ui-dialog').watch({
-      id: 'dialog',
-      properties: 'display',
-      callback() {
-        expect($('.ui-dialog')).toHaveCss({display: 'block'});
-        removeWatch($('.ui-dialog'), 'dialog');
-        done();
-      }
+    showPalette(() => {
+      expect($('.ui-dialog')).toHaveCss({display: 'block'});
+      done();
     });
-    specTimer(1000).then(() => {
-      $('.emojidex-palette-button')[0].click();
-    })
   });
 
   // FIXME: this example isn't correct.

--- a/spec/palette/base.js
+++ b/spec/palette/base.js
@@ -1,5 +1,5 @@
-describe("emojidexPalette:Base", function() {
-  beforeAll(function(done) {
+describe("emojidexPalette:Base", () => {
+  beforeAll(done => {
     clearStorage().then(() => {
       helperBefore();
       let limitForSpec = 1;
@@ -17,12 +17,12 @@ describe("emojidexPalette:Base", function() {
 
   afterAll(() => helperAfter());
 
-  it("created emojidexPalette button in input", (done) => {
+  it("created emojidexPalette button in input", done => {
     expect($('.emojidex-palette-button').length).toBe(1);
     done();
   })
 
-  it("show emojidexPalette", function(done) {
+  it("show emojidexPalette", done => {
     expect($('.ui-dialog')).toHaveCss({display: 'none'});
 
     $('.ui-dialog').watch({
@@ -34,9 +34,8 @@ describe("emojidexPalette:Base", function() {
         done();
       }
     });
-    spec_timer({
-      time: 1000,
-      callback: () => { $('.emojidex-palette-button')[0].click(); }
+    specTimer(1000).then(() => {
+      $('.emojidex-palette-button')[0].click();
     })
   });
 
@@ -47,7 +46,7 @@ describe("emojidexPalette:Base", function() {
   //   $($('#tab-content-cosmos').find('.emoji-btn')[0]).click()
   //   expect(clipboard.clipboardAction.selectedText).toBe clipboard_text
 
-  it('close emojidexPalette', function() {
+  it('close emojidexPalette', () => {
     $('button.pull-right[aria-label="Close"]').click();
     expect($('.ui-dialog')).toHaveCss({display: 'none'});
   });

--- a/spec/palette/category.js
+++ b/spec/palette/category.js
@@ -1,5 +1,5 @@
-describe("emojidexPalette:Category", function() {
-  beforeAll(function(done) {
+describe("emojidexPalette:Category", () => {
+  beforeAll(done => {
     clearStorage().then(() => {
       helperBefore();
       let limitForSpec = 1;
@@ -20,8 +20,8 @@ describe("emojidexPalette:Category", function() {
     helperAfter();
   });
 
-  describe('category tab', function() {
-    it("changes to a specific category", function(done) {
+  describe('category tab', () => {
+    it("changes to a specific category", done => {
       $('#tab-content-faces').watch({
         id: 'content_faces',
         properties: 'prop_innerHTML',
@@ -48,7 +48,7 @@ describe("emojidexPalette:Category", function() {
       $('.emojidex-palette-button')[0].click();
     });
 
-    it('switches to the next page', function(done) {
+    it('switches to the next page', done => {
       $('#tab-content-faces').watch({
         id: "content_faces",
         properties: 'prop_innerHTML',
@@ -62,7 +62,7 @@ describe("emojidexPalette:Category", function() {
       $('#tab-content-faces').find('.pagination .palette-pager')[1].click();
     });
 
-    it('switches to the previous page', function(done) {
+    it('switches to the previous page', done => {
       $('#tab-content-faces').watch({
         id: "content_faces",
         properties: 'prop_innerHTML',

--- a/spec/palette/category.js
+++ b/spec/palette/category.js
@@ -11,54 +11,52 @@ describe("emojidexPalette:Category", () => {
     helperAfter();
   });
 
-  describe('category tab', () => {
-    it("changes to a specific category", done => {
-      $('#tab-content-faces').watch({
-        id: 'content_faces',
-        properties: 'prop_innerHTML',
-        watchChildren: true,
-        callback(data, i) {
-          if (data.vals[0].match(/category-emoji-list/)) {
-            expect($('#tab-faces')).toHaveClass('active');
-            expect($('#tab-content-faces')).toHaveClass('active');
-            expect($('#tab-content-faces').find('img').length).toBeTruthy();
-            removeWatch($('#tab-content-faces'), 'content_faces');
-            done();
-          }
-        }
-      });
-
-      showPalette(() => {
-        $('#tab-faces a').click();
-      });
-    });
-
-    it('switches to the next page', done => {
-      $('#tab-content-faces').watch({
-        id: "content_faces",
-        properties: 'prop_innerHTML',
-        watchChildren: true,
-        callback(data, i, mutations) {
-          expect($(data.vals[0]).find('ul.pagination li.disabled span').text().substr(0, 1)).toBe('2');
+  it("changes to a specific category", done => {
+    $('#tab-content-faces').watch({
+      id: 'content_faces',
+      properties: 'prop_innerHTML',
+      watchChildren: true,
+      callback(data, i) {
+        if (data.vals[0].match(/category-emoji-list/)) {
+          expect($('#tab-faces')).toHaveClass('active');
+          expect($('#tab-content-faces')).toHaveClass('active');
+          expect($('#tab-content-faces').find('img').length).toBeTruthy();
           removeWatch($('#tab-content-faces'), 'content_faces');
           done();
         }
-      });
-      $('#tab-content-faces').find('.pagination .palette-pager')[1].click();
+      }
     });
 
-    it('switches to the previous page', done => {
-      $('#tab-content-faces').watch({
-        id: "content_faces",
-        properties: 'prop_innerHTML',
-        watchChildren: true,
-        callback(data, i, mutations) {
-          expect($(data.vals[0]).find('ul.pagination li.palette-num span').text().substr(0, 1)).toBe('1');
-          removeWatch($('#tab-content-faces'), 'content_faces');
-          done();
-        }
-      });
-      $('#tab-content-faces').find('.pagination .palette-pager')[0].click();
+    showPalette(() => {
+      $('#tab-faces a').click();
     });
+  });
+
+  it('switches to the next page', done => {
+    $('#tab-content-faces').watch({
+      id: "content_faces",
+      properties: 'prop_innerHTML',
+      watchChildren: true,
+      callback(data, i, mutations) {
+        expect($(data.vals[0]).find('ul.pagination li.disabled span').text().substr(0, 1)).toBe('2');
+        removeWatch($('#tab-content-faces'), 'content_faces');
+        done();
+      }
+    });
+    $('#tab-content-faces').find('.pagination .palette-pager')[1].click();
+  });
+
+  it('switches to the previous page', done => {
+    $('#tab-content-faces').watch({
+      id: "content_faces",
+      properties: 'prop_innerHTML',
+      watchChildren: true,
+      callback(data, i, mutations) {
+        expect($(data.vals[0]).find('ul.pagination li.palette-num span').text().substr(0, 1)).toBe('1');
+        removeWatch($('#tab-content-faces'), 'content_faces');
+        done();
+      }
+    });
+    $('#tab-content-faces').find('.pagination .palette-pager')[0].click();
   });
 });

--- a/spec/palette/category.js
+++ b/spec/palette/category.js
@@ -2,16 +2,7 @@ describe("emojidexPalette:Category", () => {
   beforeAll(done => {
     clearStorage().then(() => {
       helperBefore();
-      let limitForSpec = 1;
-      $("#palette-btn").emojidexPalette({
-        paletteEmojisLimit: limitForSpec,
-        onComplete: () => {
-          $("#palette-input").emojidexPalette({
-            paletteEmojisLimit: limitForSpec,
-            onComplete: () => { done(); }
-          });
-        }
-      });
+      preparePaletteButtons(done);
     });
   });
 
@@ -37,15 +28,9 @@ describe("emojidexPalette:Category", () => {
         }
       });
 
-      $('.ui-dialog').watch({
-        id: 'dialog',
-        properties: 'display',
-        callback() {
-          removeWatch($('.ui-dialog'), 'dialog');
-          $('#tab-faces a').click();
-        }
+      showPalette(() => {
+        $('#tab-faces a').click();
       });
-      $('.emojidex-palette-button')[0].click();
     });
 
     it('switches to the next page', done => {

--- a/spec/palette/search.js
+++ b/spec/palette/search.js
@@ -2,16 +2,7 @@ describe("emojidexPalette:Search", () => {
   beforeAll(done => {
     clearStorage().then(() => {
       helperBefore();
-      let limitForSpec = 1;
-      $("#palette-btn").emojidexPalette({
-        paletteEmojisLimit: limitForSpec,
-        onComplete: () => {
-          $("#palette-input").emojidexPalette({
-            paletteEmojisLimit: limitForSpec,
-            onComplete: () => { done(); }
-          });
-        }
-      });
+      preparePaletteButtons(done);
     });
   });
 
@@ -34,17 +25,10 @@ describe("emojidexPalette:Search", () => {
       }
     });
 
-    $('.ui-dialog').watch({
-      id: 'dialog',
-      properties: 'display',
-      callback() {
-        removeWatch($('.ui-dialog'), 'dialog');
-
-        $('#tab-search a').click();
-        $('#palette-emoji-search-input').val('test');
-        $('#palette-emoji-search-submit').click();
-      }
+    showPalette(() => {
+      $('#tab-search a').click();
+      $('#palette-emoji-search-input').val('test');
+      $('#palette-emoji-search-submit').click();
     });
-    $('.emojidex-palette-button')[0].click();
   });
 });

--- a/spec/palette/search.js
+++ b/spec/palette/search.js
@@ -1,5 +1,5 @@
-describe("emojidexPalette:Search", function() {
-  beforeAll(function(done) {
+describe("emojidexPalette:Search", () => {
+  beforeAll(done => {
     clearStorage().then(() => {
       helperBefore();
       let limitForSpec = 1;
@@ -20,7 +20,7 @@ describe("emojidexPalette:Search", function() {
     helperAfter();
   });
 
-  it('search tab', function(done){
+  it('search tab', done => {
     $('#tab-content-search').watch({
       id: 'content_search',
       properties: 'prop_innerHTML',

--- a/spec/palette/user_favorite.js
+++ b/spec/palette/user_favorite.js
@@ -1,5 +1,5 @@
-describe("emojidexPalette:User:Favorite", function() {
-  beforeAll(function(done) {
+describe("emojidexPalette:User:Favorite", () => {
+  beforeAll(done => {
     clearStorage().then(() => {
       helperBefore();
       let limitForSpec = 1;
@@ -20,8 +20,8 @@ describe("emojidexPalette:User:Favorite", function() {
     helperAfter();
   });
 
-  describe('user tab', function() {
-    it('show favorite tab [Requires a premium user account]', function(done) {
+  describe('user tab', () => {
+    it('show favorite tab [Requires a premium user account]', done => {
       if (typeof user_info === 'undefined' || user_info === null) { pending(); }
       $('#tab-content-user').watch({
         id: 'content_user_favorite',
@@ -61,40 +61,34 @@ describe("emojidexPalette:User:Favorite", function() {
       $('.emojidex-palette-button')[0].click();
     });
 
-    it('switches to the next page [Requires a premium user account and many favorites]', function(done) {
+    it('switches to the next page [Requires a premium user account and many favorites]', done => {
       if (typeof user_info === 'undefined' || user_info === null) { pending(); }
       $('#user-tab-content').watch({
         id: "content_user_next",
         properties: 'prop_innerHTML',
         watchChildren: true,
         callback(data, i, mutations) {
-          spec_timer({
-            time: 1000,
-            callback() {
-              expect($(data.vals[0]).find('.favorite-pagination ul.pagination li.palette-num span').text().substr(0, 1)).toBe('2');
-              removeWatch($('#user-tab-content'), 'content_user_next');
-              done();
-            }
+          specTimer(1000).then(() => {
+            expect($(data.vals[0]).find('.favorite-pagination ul.pagination li.palette-num span').text().substr(0, 1)).toBe('2');
+            removeWatch($('#user-tab-content'), 'content_user_next');
+            done();
           });
         }
       });
       $('#tab-content-user-favorite').find('.pagination .palette-pager')[1].click();
     });
 
-    it('switches to the previous page [Requires a premium user account and many favorites]', function(done) {
+    it('switches to the previous page [Requires a premium user account and many favorites]', done => {
       if (typeof user_info === 'undefined' || user_info === null) { pending(); }
       $('#user-tab-content').watch({
         id: "content_user_prev",
         properties: 'prop_innerHTML',
         watchChildren: true,
         callback(data, i, mutations) {
-          spec_timer({
-            time: 1000,
-            callback() {
-              expect($(data.vals[0]).find('.favorite-pagination ul.pagination li.palette-num span').text().substr(0, 1)).toBe('1');
-              removeWatch($('#user-tab-content'), 'content_user_prev');
-              done();
-            }
+          specTimer(1000).then(() => {
+            expect($(data.vals[0]).find('.favorite-pagination ul.pagination li.palette-num span').text().substr(0, 1)).toBe('1');
+            removeWatch($('#user-tab-content'), 'content_user_prev');
+            done();
           });
         }
       });

--- a/spec/palette/user_favorite.js
+++ b/spec/palette/user_favorite.js
@@ -11,69 +11,67 @@ describe("emojidexPalette:User:Favorite", () => {
     helperAfter();
   });
 
-  describe('user tab', () => {
-    it('show favorite tab [Requires a premium user account]', done => {
-      if (typeof user_info === 'undefined' || user_info === null) { pending(); }
-      $('#tab-content-user').watch({
-        id: 'content_user_favorite',
-        properties: 'prop_innerHTML',
-        watchChildren: true,
-        callback(data, i) {
-          if (data.vals[0].match(/favorite-emoji-list/)) {
-            expect($('#tab-content-user-favorite').find('img').length).toBeTruthy();
-            removeWatch($('#tab-content-user'), 'content_user_favorite');
-            done();
-          }
+  it('show favorite tab [Requires a premium user account]', done => {
+    if (typeof user_info === 'undefined' || user_info === null) { pending(); }
+    $('#tab-content-user').watch({
+      id: 'content_user_favorite',
+      properties: 'prop_innerHTML',
+      watchChildren: true,
+      callback(data, i) {
+        if (data.vals[0].match(/favorite-emoji-list/)) {
+          expect($('#tab-content-user-favorite').find('img').length).toBeTruthy();
+          removeWatch($('#tab-content-user'), 'content_user_favorite');
+          done();
         }
-      });
-
-      $('#tab-content-user').watch({
-        id: 'content_user',
-        properties: 'prop_innerHTML',
-        watchChildren: true,
-        callback(data, i) {
-          removeWatch($('#tab-content-user'), 'content_user');
-          $('#tab-user-favorite a').click();
-        }
-      });
-
-      showPalette(() => {
-        loginUser(user_info.auth_user, user_info.password);
-      });
+      }
     });
 
-    it('switches to the next page [Requires a premium user account and many favorites]', done => {
-      if (typeof user_info === 'undefined' || user_info === null) { pending(); }
-      $('#user-tab-content').watch({
-        id: "content_user_next",
-        properties: 'prop_innerHTML',
-        watchChildren: true,
-        callback(data, i, mutations) {
-          specTimer(1000).then(() => {
-            expect($(data.vals[0]).find('.favorite-pagination ul.pagination li.palette-num span').text().substr(0, 1)).toBe('2');
-            removeWatch($('#user-tab-content'), 'content_user_next');
-            done();
-          });
-        }
-      });
-      $('#tab-content-user-favorite').find('.pagination .palette-pager')[1].click();
+    $('#tab-content-user').watch({
+      id: 'content_user',
+      properties: 'prop_innerHTML',
+      watchChildren: true,
+      callback(data, i) {
+        removeWatch($('#tab-content-user'), 'content_user');
+        $('#tab-user-favorite a').click();
+      }
     });
 
-    it('switches to the previous page [Requires a premium user account and many favorites]', done => {
-      if (typeof user_info === 'undefined' || user_info === null) { pending(); }
-      $('#user-tab-content').watch({
-        id: "content_user_prev",
-        properties: 'prop_innerHTML',
-        watchChildren: true,
-        callback(data, i, mutations) {
-          specTimer(1000).then(() => {
-            expect($(data.vals[0]).find('.favorite-pagination ul.pagination li.palette-num span').text().substr(0, 1)).toBe('1');
-            removeWatch($('#user-tab-content'), 'content_user_prev');
-            done();
-          });
-        }
-      });
-      $('#tab-content-user-favorite').find('.pagination .palette-pager')[0].click();
+    showPalette(() => {
+      loginUser(user_info.auth_user, user_info.password);
     });
+  });
+
+  it('switches to the next page [Requires a premium user account and many favorites]', done => {
+    if (typeof user_info === 'undefined' || user_info === null) { pending(); }
+    $('#user-tab-content').watch({
+      id: "content_user_next",
+      properties: 'prop_innerHTML',
+      watchChildren: true,
+      callback(data, i, mutations) {
+        specTimer(1000).then(() => {
+          expect($(data.vals[0]).find('.favorite-pagination ul.pagination li.palette-num span').text().substr(0, 1)).toBe('2');
+          removeWatch($('#user-tab-content'), 'content_user_next');
+          done();
+        });
+      }
+    });
+    $('#tab-content-user-favorite').find('.pagination .palette-pager')[1].click();
+  });
+
+  it('switches to the previous page [Requires a premium user account and many favorites]', done => {
+    if (typeof user_info === 'undefined' || user_info === null) { pending(); }
+    $('#user-tab-content').watch({
+      id: "content_user_prev",
+      properties: 'prop_innerHTML',
+      watchChildren: true,
+      callback(data, i, mutations) {
+        specTimer(1000).then(() => {
+          expect($(data.vals[0]).find('.favorite-pagination ul.pagination li.palette-num span').text().substr(0, 1)).toBe('1');
+          removeWatch($('#user-tab-content'), 'content_user_prev');
+          done();
+        });
+      }
+    });
+    $('#tab-content-user-favorite').find('.pagination .palette-pager')[0].click();
   });
 });

--- a/spec/palette/user_favorite.js
+++ b/spec/palette/user_favorite.js
@@ -2,16 +2,7 @@ describe("emojidexPalette:User:Favorite", () => {
   beforeAll(done => {
     clearStorage().then(() => {
       helperBefore();
-      let limitForSpec = 1;
-      $("#palette-btn").emojidexPalette({
-        paletteEmojisLimit: limitForSpec,
-        onComplete: () => {
-          $("#palette-input").emojidexPalette({
-            paletteEmojisLimit: limitForSpec,
-            onComplete: () => { done(); }
-          });
-        }
-      });
+      preparePaletteButtons(done);
     });
   });
 
@@ -46,19 +37,9 @@ describe("emojidexPalette:User:Favorite", () => {
         }
       });
 
-      $('.ui-dialog').watch({
-        id: 'dialog',
-        properties: 'display',
-        callback() {
-          removeWatch($('.ui-dialog'), 'dialog');
-
-          $('#tab-user a').click();
-          $('#palette-emoji-username-input').val(user_info.auth_user);
-          $('#palette-emoji-password-input').val(user_info.password);
-          $('#palette-emoji-login-submit').click();
-        }
+      showPalette(() => {
+        loginUser(user_info.auth_user, user_info.password);
       });
-      $('.emojidex-palette-button')[0].click();
     });
 
     it('switches to the next page [Requires a premium user account and many favorites]', done => {

--- a/spec/palette/user_followers.js
+++ b/spec/palette/user_followers.js
@@ -2,16 +2,7 @@ describe("emojidexPalette:User:Followers", () => {
   beforeAll(done => {
     clearStorage().then(() => {
       helperBefore();
-      let limitForSpec = 1;
-      $("#palette-btn").emojidexPalette({
-        paletteEmojisLimit: limitForSpec,
-        onComplete: () => {
-          $("#palette-input").emojidexPalette({
-            paletteEmojisLimit: limitForSpec,
-            onComplete: () => { done(); }
-          });
-        }
-      });
+      preparePaletteButtons(done);
     });
   });
 
@@ -46,19 +37,9 @@ describe("emojidexPalette:User:Followers", () => {
       }
     });
 
-    $('.ui-dialog').watch({
-      id: 'dialog',
-      properties: 'display',
-      callback() {
-        removeWatch($('.ui-dialog'), 'dialog');
-
-        $('#tab-user a').click();
-        $('#palette-emoji-username-input').val(user_info.auth_user);
-        $('#palette-emoji-password-input').val(user_info.password);
-        $('#palette-emoji-login-submit').click();
-      }
+    showPalette(() => {
+      loginUser(user_info.auth_user, user_info.password);
     });
-    $('.emojidex-palette-button')[0].click();
   });
 
   it('show followers user info [Requires a premium user account and followers user]', done => {
@@ -95,7 +76,7 @@ describe("emojidexPalette:User:Followers", () => {
     $($(`${selectorCurrentUserInfo} .palette-pager`)[1]).click();
   });
 
-  it('show followers user emoji previous [Requires a premium user account and followers user]', done =>) {
+  it('show followers user emoji previous [Requires a premium user account and followers user]', done => {
     if (typeof user_info === 'undefined' || user_info === null) { pending(); }
     const selectorCurrentUserInfo = '#follow-followers .user-info.on';
     $(selectorCurrentUserInfo).watch({

--- a/spec/palette/user_followers.js
+++ b/spec/palette/user_followers.js
@@ -1,5 +1,5 @@
-describe("emojidexPalette:User:Followers", function() {
-  beforeAll(function(done) {
+describe("emojidexPalette:User:Followers", () => {
+  beforeAll(done => {
     clearStorage().then(() => {
       helperBefore();
       let limitForSpec = 1;
@@ -20,7 +20,7 @@ describe("emojidexPalette:User:Followers", function() {
     helperAfter();
   });
 
-  it('show followers tab [Requires a premium user account and followers user]', function(done) {
+  it('show followers tab [Requires a premium user account and followers user]', done => {
     if (typeof user_info === 'undefined' || user_info === null) { pending(); }
 
     $('#tab-content-user').watch({
@@ -28,23 +28,20 @@ describe("emojidexPalette:User:Followers", function() {
       properties: 'prop_innerHTML',
       watchChildren: true,
       callback(data, i) {
-        spec_timer({
-          time: 1000,
-          callback() {
-            removeWatch($('#tab-content-user'), 'watcher');
+        specTimer(1000).then(() => {
+          removeWatch($('#tab-content-user'), 'watcher');
 
-            $('#follow-followers').watch({
-              id: "watcher",
-              properties: 'attr_class',
-              callback(data, i) {
-                expect($('#follow-followers .users .btn').length).toBeTruthy();
-                removeWatch($('#follow-followers'), 'watcher');
-                done();
-              }
-            });
+          $('#follow-followers').watch({
+            id: "watcher",
+            properties: 'attr_class',
+            callback(data, i) {
+              expect($('#follow-followers .users .btn').length).toBeTruthy();
+              removeWatch($('#follow-followers'), 'watcher');
+              done();
+            }
+          });
 
-            $('#tab-user-followers a').click();
-          }
+          $('#tab-user-followers a').click();
         });
       }
     });
@@ -64,7 +61,7 @@ describe("emojidexPalette:User:Followers", function() {
     $('.emojidex-palette-button')[0].click();
   });
 
-  it('show followers user info [Requires a premium user account and followers user]', function(done) {
+  it('show followers user info [Requires a premium user account and followers user]', done => {
     if (typeof user_info === 'undefined' || user_info === null) { pending(); }
     $('#follow-followers .user-info').watch({
       id: "watcher",
@@ -81,7 +78,7 @@ describe("emojidexPalette:User:Followers", function() {
     });
   });
 
-  it('show followers user emoji next [Requires premium a user account and followers user]', function(done) {
+  it('show followers user emoji next [Requires premium a user account and followers user]', done => {
     if (typeof user_info === 'undefined' || user_info === null) { pending(); }
     const selectorCurrentUserInfo = '#follow-followers .user-info.on';
     $(selectorCurrentUserInfo).watch({
@@ -98,7 +95,7 @@ describe("emojidexPalette:User:Followers", function() {
     $($(`${selectorCurrentUserInfo} .palette-pager`)[1]).click();
   });
 
-  it('show followers user emoji previous [Requires a premium user account and followers user]', function(done) {
+  it('show followers user emoji previous [Requires a premium user account and followers user]', done =>) {
     if (typeof user_info === 'undefined' || user_info === null) { pending(); }
     const selectorCurrentUserInfo = '#follow-followers .user-info.on';
     $(selectorCurrentUserInfo).watch({

--- a/spec/palette/user_following.js
+++ b/spec/palette/user_following.js
@@ -2,16 +2,7 @@ describe("emojidexPalette:User:Following", () => {
   beforeAll(done => {
     clearStorage().then(() => {
       helperBefore();
-      let limitForSpec = 1;
-      $("#palette-btn").emojidexPalette({
-        paletteEmojisLimit: limitForSpec,
-        onComplete: () => {
-          $("#palette-input").emojidexPalette({
-            paletteEmojisLimit: limitForSpec,
-            onComplete: () => { done(); }
-          });
-        }
-      });
+      preparePaletteButtons(done);
     });
   });
 
@@ -46,19 +37,9 @@ describe("emojidexPalette:User:Following", () => {
       }
     });
 
-    $('.ui-dialog').watch({
-      id: 'dialog',
-      properties: 'display',
-      callback() {
-        removeWatch($('.ui-dialog'), 'dialog');
-
-        $('#tab-user a').click();
-        $('#palette-emoji-username-input').val(user_info.auth_user);
-        $('#palette-emoji-password-input').val(user_info.password);
-        $('#palette-emoji-login-submit').click();
-      }
+    showPalette(() => {
+      loginUser(user_info.auth_user, user_info.password);
     });
-    $('.emojidex-palette-button')[0].click();
   });
 
   it('show following user info [Requires a user account and following user]', done => {

--- a/spec/palette/user_following.js
+++ b/spec/palette/user_following.js
@@ -1,5 +1,5 @@
-describe("emojidexPalette:User:Following", function() {
-  beforeAll(function(done) {
+describe("emojidexPalette:User:Following", () => {
+  beforeAll(done => {
     clearStorage().then(() => {
       helperBefore();
       let limitForSpec = 1;
@@ -20,7 +20,7 @@ describe("emojidexPalette:User:Following", function() {
     helperAfter();
   });
 
-  it('show following tab [Requires a user account and following user]', function(done) {
+  it('show following tab [Requires a user account and following user]', done => {
     if (typeof user_info === 'undefined' || user_info === null) { pending(); }
 
     $('#tab-content-user').watch({
@@ -28,23 +28,20 @@ describe("emojidexPalette:User:Following", function() {
       properties: 'prop_innerHTML',
       watchChildren: true,
       callback(data, i) {
-        spec_timer({
-          time: 1000,
-          callback() {
-            removeWatch($('#tab-content-user'), 'watcher');
+        specTimer(1000).then(() => {
+          removeWatch($('#tab-content-user'), 'watcher');
 
-            $('#follow-following').watch({
-              id: "watcher",
-              properties: 'attr_class',
-              callback(data, i) {
-                expect($('#follow-following .users .btn').length).toBeTruthy();
-                removeWatch($('#follow-following'), 'watcher');
-                done();
-              }
-            });
+          $('#follow-following').watch({
+            id: "watcher",
+            properties: 'attr_class',
+            callback(data, i) {
+              expect($('#follow-following .users .btn').length).toBeTruthy();
+              removeWatch($('#follow-following'), 'watcher');
+              done();
+            }
+          });
 
-            $('#tab-user-following a').click();
-          }
+          $('#tab-user-following a').click();
         });
       }
     });
@@ -64,7 +61,7 @@ describe("emojidexPalette:User:Following", function() {
     $('.emojidex-palette-button')[0].click();
   });
 
-  it('show following user info [Requires a user account and following user]', function(done) {
+  it('show following user info [Requires a user account and following user]', done => {
     if (typeof user_info === 'undefined' || user_info === null) { pending(); }
     $('#follow-following .user-info').watch({
       id: "watcher",
@@ -81,7 +78,7 @@ describe("emojidexPalette:User:Following", function() {
     });
   });
 
-  it('show following user emoji next [Requires a user account and following user]', function(done) {
+  it('show following user emoji next [Requires a user account and following user]', done => {
     if (typeof user_info === 'undefined' || user_info === null) { pending(); }
     const selectorCurrentUserInfo = '#follow-following .user-info.on';
     $(selectorCurrentUserInfo).watch({
@@ -98,7 +95,7 @@ describe("emojidexPalette:User:Following", function() {
     $($(`${selectorCurrentUserInfo} .palette-pager`)[1]).click();
   });
 
-  it('show following user emoji previous [Requires a user account and following user]', function(done) {
+  it('show following user emoji previous [Requires a user account and following user]', done => {
     if (typeof user_info === 'undefined' || user_info === null) { pending(); }
     const selectorCurrentUserInfo = '#follow-following .user-info.on';
     $(selectorCurrentUserInfo).watch({

--- a/spec/palette/user_history.js
+++ b/spec/palette/user_history.js
@@ -2,16 +2,7 @@ describe("emojidexPalette:User:History", () => {
   beforeAll(done => {
     clearStorage().then(() => {
       helperBefore();
-      let limitForSpec = 1;
-      $("#palette-btn").emojidexPalette({
-        paletteEmojisLimit: limitForSpec,
-        onComplete: () => {
-          $("#palette-input").emojidexPalette({
-            paletteEmojisLimit: limitForSpec,
-            onComplete: () => { done(); }
-          });
-        }
-      });
+      preparePaletteButtons(done);
     });
   });
 
@@ -48,19 +39,9 @@ describe("emojidexPalette:User:History", () => {
         }
       });
 
-      $('.ui-dialog').watch({
-        id: 'dialog',
-        properties: 'display',
-        callback() {
-          removeWatch($('.ui-dialog'), 'dialog');
-
-          $('#tab-user a').click();
-          $('#palette-emoji-username-input').val(user_info.auth_user);
-          $('#palette-emoji-password-input').val(user_info.password);
-          $('#palette-emoji-login-submit').click();
-        }
+      showPalette(() => {
+        loginUser(user_info.auth_user, user_info.password);
       });
-      $('.emojidex-palette-button')[0].click();
     });
 
     it('switches to the next page [Requires a premium user account and many history]', done => {

--- a/spec/palette/user_history.js
+++ b/spec/palette/user_history.js
@@ -11,71 +11,69 @@ describe("emojidexPalette:User:History", () => {
     helperAfter();
   });
 
-  describe('user tab', () => {
-    it('show history tab [Requires a premium user account]', done => {
-      if (typeof user_info === 'undefined' || user_info === null) { pending(); }
-      $('#tab-content-user').watch({
-        id: 'content_user_history',
-        properties: 'prop_innerHTML',
-        watchChildren: true,
-        callback(data, i) {
-          if (data.vals[0].match(/history-emoji-list/)) {
-            expect($('#tab-content-user-history').find('img').length).toBeTruthy();
-            removeWatch($('#tab-content-user'), 'content_user_history');
-            done();
-          }
+  it('show history tab [Requires a premium user account]', done => {
+    if (typeof user_info === 'undefined' || user_info === null) { pending(); }
+    $('#tab-content-user').watch({
+      id: 'content_user_history',
+      properties: 'prop_innerHTML',
+      watchChildren: true,
+      callback(data, i) {
+        if (data.vals[0].match(/history-emoji-list/)) {
+          expect($('#tab-content-user-history').find('img').length).toBeTruthy();
+          removeWatch($('#tab-content-user'), 'content_user_history');
+          done();
         }
-      });
-
-      $('#tab-content-user').watch({
-        id: 'content_user',
-        properties: 'prop_innerHTML',
-        watchChildren: true,
-        callback(data, i) {
-          specTimer(1000).then(() => {
-            removeWatch($('#tab-content-user'), 'content_user');
-            $('#tab-user-history a').click();
-          });
-        }
-      });
-
-      showPalette(() => {
-        loginUser(user_info.auth_user, user_info.password);
-      });
+      }
     });
 
-    it('switches to the next page [Requires a premium user account and many history]', done => {
-      if (typeof user_info === 'undefined' || user_info === null) { pending(); }
-      $('#user-tab-content').watch({
-        id: "content_user_history_next",
-        properties: 'prop_innerHTML',
-        watchChildren: true,
-        callback(data, i, mutations) {
-          specTimer(1000).then(() => {
-            expect($(data.vals[0]).find('.history-pagination ul.pagination li.palette-num span').text().substr(0, 1)).toBe('2');
-            removeWatch($('#user-tab-content'), 'content_user_history_next');
-            done();
-          });
-        }
-      });
-      $('#tab-content-user-history').find('.pagination .palette-pager')[1].click();
+    $('#tab-content-user').watch({
+      id: 'content_user',
+      properties: 'prop_innerHTML',
+      watchChildren: true,
+      callback(data, i) {
+        specTimer(1000).then(() => {
+          removeWatch($('#tab-content-user'), 'content_user');
+          $('#tab-user-history a').click();
+        });
+      }
     });
 
-    it('switches to the previous page [Requires a premium user account and many history]', done => {
-      if (typeof user_info === 'undefined' || user_info === null) { pending(); }
-      $('#user-tab-content').watch({
-        id: "content_user_history_prev",
-        properties: 'prop_innerHTML',
-        watchChildren: true,
-        callback(data, i, mutations) {
-          specTimer(1000).then(() => {
-            expect($(data.vals[0]).find('.history-pagination ul.pagination li.palette-num span').text().substr(0, 1)).toBe('1');
-            removeWatch($('#user-tab-content'), 'content_user_history_prev');
-            done();
-          });
-        }
-      });
-      $('#tab-content-user-history').find('.pagination .palette-pager')[0].click();
+    showPalette(() => {
+      loginUser(user_info.auth_user, user_info.password);
     });
+  });
+
+  it('switches to the next page [Requires a premium user account and many history]', done => {
+    if (typeof user_info === 'undefined' || user_info === null) { pending(); }
+    $('#user-tab-content').watch({
+      id: "content_user_history_next",
+      properties: 'prop_innerHTML',
+      watchChildren: true,
+      callback(data, i, mutations) {
+        specTimer(1000).then(() => {
+          expect($(data.vals[0]).find('.history-pagination ul.pagination li.palette-num span').text().substr(0, 1)).toBe('2');
+          removeWatch($('#user-tab-content'), 'content_user_history_next');
+          done();
+        });
+      }
+    });
+    $('#tab-content-user-history').find('.pagination .palette-pager')[1].click();
+  });
+
+  it('switches to the previous page [Requires a premium user account and many history]', done => {
+    if (typeof user_info === 'undefined' || user_info === null) { pending(); }
+    $('#user-tab-content').watch({
+      id: "content_user_history_prev",
+      properties: 'prop_innerHTML',
+      watchChildren: true,
+      callback(data, i, mutations) {
+        specTimer(1000).then(() => {
+          expect($(data.vals[0]).find('.history-pagination ul.pagination li.palette-num span').text().substr(0, 1)).toBe('1');
+          removeWatch($('#user-tab-content'), 'content_user_history_prev');
+          done();
+        });
+      }
+    });
+    $('#tab-content-user-history').find('.pagination .palette-pager')[0].click();
   });
 });

--- a/spec/palette/user_history.js
+++ b/spec/palette/user_history.js
@@ -1,5 +1,5 @@
-describe("emojidexPalette:User:History", function() {
-  beforeAll(function(done) {
+describe("emojidexPalette:User:History", () => {
+  beforeAll(done => {
     clearStorage().then(() => {
       helperBefore();
       let limitForSpec = 1;
@@ -20,8 +20,8 @@ describe("emojidexPalette:User:History", function() {
     helperAfter();
   });
 
-  describe('user tab', function() {
-    it('show history tab [Requires a premium user account]', function(done) {
+  describe('user tab', () => {
+    it('show history tab [Requires a premium user account]', done => {
       if (typeof user_info === 'undefined' || user_info === null) { pending(); }
       $('#tab-content-user').watch({
         id: 'content_user_history',
@@ -41,12 +41,9 @@ describe("emojidexPalette:User:History", function() {
         properties: 'prop_innerHTML',
         watchChildren: true,
         callback(data, i) {
-          spec_timer({
-            time: 1000,
-            callback() {
-              removeWatch($('#tab-content-user'), 'content_user');
-              $('#tab-user-history a').click();
-            }
+          specTimer(1000).then(() => {
+            removeWatch($('#tab-content-user'), 'content_user');
+            $('#tab-user-history a').click();
           });
         }
       });
@@ -66,40 +63,34 @@ describe("emojidexPalette:User:History", function() {
       $('.emojidex-palette-button')[0].click();
     });
 
-    it('switches to the next page [Requires a premium user account and many history]', function(done) {
+    it('switches to the next page [Requires a premium user account and many history]', done => {
       if (typeof user_info === 'undefined' || user_info === null) { pending(); }
       $('#user-tab-content').watch({
         id: "content_user_history_next",
         properties: 'prop_innerHTML',
         watchChildren: true,
         callback(data, i, mutations) {
-          spec_timer({
-            time: 1000,
-            callback() {
-              expect($(data.vals[0]).find('.history-pagination ul.pagination li.palette-num span').text().substr(0, 1)).toBe('2');
-              removeWatch($('#user-tab-content'), 'content_user_history_next');
-              done();
-            }
+          specTimer(1000).then(() => {
+            expect($(data.vals[0]).find('.history-pagination ul.pagination li.palette-num span').text().substr(0, 1)).toBe('2');
+            removeWatch($('#user-tab-content'), 'content_user_history_next');
+            done();
           });
         }
       });
       $('#tab-content-user-history').find('.pagination .palette-pager')[1].click();
     });
 
-    it('switches to the previous page [Requires a premium user account and many history]', function(done) {
+    it('switches to the previous page [Requires a premium user account and many history]', done => {
       if (typeof user_info === 'undefined' || user_info === null) { pending(); }
       $('#user-tab-content').watch({
         id: "content_user_history_prev",
         properties: 'prop_innerHTML',
         watchChildren: true,
         callback(data, i, mutations) {
-          spec_timer({
-            time: 1000,
-            callback() {
-              expect($(data.vals[0]).find('.history-pagination ul.pagination li.palette-num span').text().substr(0, 1)).toBe('1');
-              removeWatch($('#user-tab-content'), 'content_user_history_prev');
-              done();
-            }
+          specTimer(1000).then(() => {
+            expect($(data.vals[0]).find('.history-pagination ul.pagination li.palette-num span').text().substr(0, 1)).toBe('1');
+            removeWatch($('#user-tab-content'), 'content_user_history_prev');
+            done();
           });
         }
       });

--- a/spec/palette/user_login.js
+++ b/spec/palette/user_login.js
@@ -91,10 +91,7 @@ describe("emojidexPalette:User:Login", () => {
         }
       }
     });
-    $('#tab-user a').click();
-    $('#palette-emoji-username-input').val(user_info.auth_user);
-    $('#palette-emoji-password-input').val(user_info.password);
-    $('#palette-emoji-login-submit').click();
+    loginUser(user_info.auth_user, user_info.password);
   });
 
    // it 'general user can not see the newest/popular emoji', (done) ->

--- a/spec/palette/user_login.js
+++ b/spec/palette/user_login.js
@@ -1,5 +1,5 @@
-describe("emojidexPalette:User:Login", function() {
-  beforeAll(function(done) {
+describe("emojidexPalette:User:Login", () => {
+  beforeAll(done => {
     clearStorage().then(() => {
       helperBefore();
       let limitForSpec = 1;
@@ -20,8 +20,8 @@ describe("emojidexPalette:User:Login", function() {
     helperAfter();
   });
 
-  describe('user tab', function() {
-    it('login (Failure)', function(done) {
+  describe('user tab', () => {
+    it('login (Failure)', done => {
       $('#tab-content-user').watch({
         id: 'content_user',
         properties: 'prop_innerHTML',
@@ -51,7 +51,7 @@ describe("emojidexPalette:User:Login", function() {
       $('.emojidex-palette-button')[0].click();
     });
 
-    it('premium user login [Requires a premium user account]', function(done) {
+    it('premium user login [Requires a premium user account]', done => {
       if (typeof user_info === 'undefined' || user_info === null) { pending(); }
       $('#tab-content-user').watch({
         id: 'content_user',
@@ -85,7 +85,7 @@ describe("emojidexPalette:User:Login", function() {
    //         spec_timer timer_option
    //   spec_timer timer_option
 
-    it('logout', function(done) {
+    it('logout', done => {
       if (typeof premium_user_info === 'undefined' || premium_user_info === null) { pending(); }
       $('#tab-content-user').watch({
         id: 'content_user',
@@ -100,7 +100,7 @@ describe("emojidexPalette:User:Login", function() {
       $('#palette-emoji-logout').click();
     });
 
-    it('general user login [Require user info]', function(done) {
+    it('general user login [Require user info]', done => {
       if (typeof user_info === 'undefined' || user_info === null) { pending(); }
       $('#tab-content-user').watch({
         id: 'content_user',
@@ -133,40 +133,37 @@ describe("emojidexPalette:User:Login", function() {
    //         spec_timer timer_option
    //   spec_timer timer_option
 
-  it('login with storage data', function(done) {
+  it('login with storage data', done => {
     if (typeof user_info === 'undefined' || user_info === null) { pending(); }
     $('#palette-btn').removeData().unbind();
     $('#emojidex-emoji-palette, .emojidex-palette-div').remove();
 
     $("#palette-btn").emojidexPalette({
       onComplete: () => {
-        spec_timer({
-          time: 1000,
-          callback: () => {
-            $('.ui-dialog').watch({
-              id: 'dialog_2',
-              properties: 'display',
-              callback() {
-                removeWatch($('.ui-dialog'), 'dialog_2');
+        specTimer(1000).then(() => {
+          $('.ui-dialog').watch({
+            id: 'dialog_2',
+            properties: 'display',
+            callback() {
+              removeWatch($('.ui-dialog'), 'dialog_2');
 
-                $('#tab-content-user').watch({
-                  id: 'content_user',
-                  properties: 'prop_innerHTML',
-                  watchChildren: true,
-                  callback(data, i) {
-                    if (data.vals[0].match(/favorite-emoji-list/)) {
-                      expect($('#tab-content-user-favorite').find('img').length).toBeTruthy();
-                      $('button.pull-right[aria-label="Close"]').click();
-                      removeWatch($('#tab-content-user'), 'content_user');
-                      return done();
-                    }
+              $('#tab-content-user').watch({
+                id: 'content_user',
+                properties: 'prop_innerHTML',
+                watchChildren: true,
+                callback(data, i) {
+                  if (data.vals[0].match(/favorite-emoji-list/)) {
+                    expect($('#tab-content-user-favorite').find('img').length).toBeTruthy();
+                    $('button.pull-right[aria-label="Close"]').click();
+                    removeWatch($('#tab-content-user'), 'content_user');
+                    return done();
                   }
-                });
-                $('#tab-user a').click();
-              }
-            });
-            $("#palette-btn").click();
-          }
+                }
+              });
+              $('#tab-user a').click();
+            }
+          });
+          $("#palette-btn").click();
         })
       }
     });

--- a/spec/palette/user_login.js
+++ b/spec/palette/user_login.js
@@ -11,92 +11,90 @@ describe("emojidexPalette:User:Login", () => {
     helperAfter();
   });
 
-  describe('user tab', () => {
-    it('login (Failure)', done => {
-      $('#tab-content-user').watch({
-        id: 'content_user',
-        properties: 'prop_innerHTML',
-        watchChildren: true,
-        callback(data, i) {
-          if (data.vals[0].match(/login-error/)) {
-            // TODO: english text
-            expect($('#login-error span').text()).toBe('Login failed. Please check your username and password or login here.');
-            removeWatch($('#tab-content-user'), 'content_user');
-            done();
-          }
-        }
-      });
-
-      showPalette(() => {
-        loginUser('aaa', 'aaa');
-      });
-    });
-
-    it('premium user login [Requires a premium user account]', done => {
-      if (typeof user_info === 'undefined' || user_info === null) { pending(); }
-      $('#tab-content-user').watch({
-        id: 'content_user',
-        properties: 'prop_innerHTML',
-        watchChildren: true,
-        callback(data, i) {
-          if (data.vals[0].match(/favorite-emoji-list/)) {
-            $('#tab-user-favorite a').click();
-            expect($('#tab-content-user-favorite').find('img').length).toBeTruthy();
-            removeWatch($('#tab-content-user'), 'content_user');
-            done();
-          }
-        }
-      });
-
-      loginUser(user_info.auth_user, user_info.password);
-    });
-
-   // it 'premium user can see the newest/popular emoji', (done) ->
-   //   pending() unless premium_user_info?
-   //   timer_option =
-   //     callback: ->
-   //       if $('#tab-content-user-newest').length
-   //         $('#tab-user-newest a').click()
-   //         expect($('#tab-content-user-newest').find('img').length).toBeTruthy()
-   //         done()
-   //       else
-   //         spec_timer timer_option
-   //   spec_timer timer_option
-
-    it('logout', done => {
-      if (typeof premium_user_info === 'undefined' || premium_user_info === null) { pending(); }
-      $('#tab-content-user').watch({
-        id: 'content_user',
-        properties: 'prop_innerHTML',
-        watchChildren: true,
-        callback(data, i) {
-          expect($('#palette-emoji-username-input')).toHaveCss({display: 'block'});
+  it('login (Failure)', done => {
+    $('#tab-content-user').watch({
+      id: 'content_user',
+      properties: 'prop_innerHTML',
+      watchChildren: true,
+      callback(data, i) {
+        if (data.vals[0].match(/login-error/)) {
+          // TODO: english text
+          expect($('#login-error span').text()).toBe('Login failed. Please check your username and password or login here.');
           removeWatch($('#tab-content-user'), 'content_user');
           done();
         }
-      });
-      $('#palette-emoji-logout').click();
+      }
     });
 
-    it('general user login [Require user info]', done => {
-      if (typeof user_info === 'undefined' || user_info === null) { pending(); }
-      $('#tab-content-user').watch({
-        id: 'content_user',
-        properties: 'prop_innerHTML',
-        watchChildren: true,
-        callback(data, i) {
-          if (data.vals[0].match(/favorite-emoji-list/)) {
-            expect($('#tab-content-user-favorite').find('img').length).toBeTruthy();
-            removeWatch($('#tab-content-user'), 'content_user');
-            done();
-          }
-        }
-      });
-      $('#tab-user a').click();
-      $('#palette-emoji-username-input').val(user_info.auth_user);
-      $('#palette-emoji-password-input').val(user_info.password);
-      $('#palette-emoji-login-submit').click();
+    showPalette(() => {
+      loginUser('aaa', 'aaa');
     });
+  });
+
+  it('premium user login [Requires a premium user account]', done => {
+    if (typeof user_info === 'undefined' || user_info === null) { pending(); }
+    $('#tab-content-user').watch({
+      id: 'content_user',
+      properties: 'prop_innerHTML',
+      watchChildren: true,
+      callback(data, i) {
+        if (data.vals[0].match(/favorite-emoji-list/)) {
+          $('#tab-user-favorite a').click();
+          expect($('#tab-content-user-favorite').find('img').length).toBeTruthy();
+          removeWatch($('#tab-content-user'), 'content_user');
+          done();
+        }
+      }
+    });
+
+    loginUser(user_info.auth_user, user_info.password);
+  });
+
+ // it 'premium user can see the newest/popular emoji', (done) ->
+ //   pending() unless premium_user_info?
+ //   timer_option =
+ //     callback: ->
+ //       if $('#tab-content-user-newest').length
+ //         $('#tab-user-newest a').click()
+ //         expect($('#tab-content-user-newest').find('img').length).toBeTruthy()
+ //         done()
+ //       else
+ //         spec_timer timer_option
+ //   spec_timer timer_option
+
+  it('logout', done => {
+    if (typeof premium_user_info === 'undefined' || premium_user_info === null) { pending(); }
+    $('#tab-content-user').watch({
+      id: 'content_user',
+      properties: 'prop_innerHTML',
+      watchChildren: true,
+      callback(data, i) {
+        expect($('#palette-emoji-username-input')).toHaveCss({display: 'block'});
+        removeWatch($('#tab-content-user'), 'content_user');
+        done();
+      }
+    });
+    $('#palette-emoji-logout').click();
+  });
+
+  it('general user login [Require user info]', done => {
+    if (typeof user_info === 'undefined' || user_info === null) { pending(); }
+    $('#tab-content-user').watch({
+      id: 'content_user',
+      properties: 'prop_innerHTML',
+      watchChildren: true,
+      callback(data, i) {
+        if (data.vals[0].match(/favorite-emoji-list/)) {
+          expect($('#tab-content-user-favorite').find('img').length).toBeTruthy();
+          removeWatch($('#tab-content-user'), 'content_user');
+          done();
+        }
+      }
+    });
+    $('#tab-user a').click();
+    $('#palette-emoji-username-input').val(user_info.auth_user);
+    $('#palette-emoji-password-input').val(user_info.password);
+    $('#palette-emoji-login-submit').click();
   });
 
    // it 'general user can not see the newest/popular emoji', (done) ->

--- a/spec/palette/user_login.js
+++ b/spec/palette/user_login.js
@@ -2,16 +2,7 @@ describe("emojidexPalette:User:Login", () => {
   beforeAll(done => {
     clearStorage().then(() => {
       helperBefore();
-      let limitForSpec = 1;
-      $("#palette-btn").emojidexPalette({
-        paletteEmojisLimit: limitForSpec,
-        onComplete: () => {
-          $("#palette-input").emojidexPalette({
-            paletteEmojisLimit: limitForSpec,
-            onComplete: () => { done(); }
-          });
-        }
-      });
+      preparePaletteButtons(done);
     });
   });
 
@@ -36,19 +27,9 @@ describe("emojidexPalette:User:Login", () => {
         }
       });
 
-      $('.ui-dialog').watch({
-        id: 'dialog',
-        properties: 'display',
-        callback() {
-          removeWatch($('.ui-dialog'), 'dialog');
-
-          $('#tab-user a').click();
-          $('#palette-emoji-username-input').val('aaa');
-          $('#palette-emoji-password-input').val('aaa');
-          $('#palette-emoji-login-submit').click();
-        }
+      showPalette(() => {
+        loginUser('aaa', 'aaa');
       });
-      $('.emojidex-palette-button')[0].click();
     });
 
     it('premium user login [Requires a premium user account]', done => {
@@ -67,10 +48,7 @@ describe("emojidexPalette:User:Login", () => {
         }
       });
 
-      $('#tab-user a').click();
-      $('#palette-emoji-username-input').val(user_info.auth_user);
-      $('#palette-emoji-password-input').val(user_info.password);
-      $('#palette-emoji-login-submit').click();
+      loginUser(user_info.auth_user, user_info.password);
     });
 
    // it 'premium user can see the newest/popular emoji', (done) ->


### PR DESCRIPTION
## 何でこの変更が必要なの？
specの可読性が下がっていたのでリファクタリングをした

## このPRでやった事は何？
- functionの書き方を統一
- spec_timerをpromiseを使用したspecTimerに変更
- 使わなくなったspec_timerメソッドを削除
- palette specのbeforeAllで実行していたパレットボタンの準備をpreparePaletteButtonsにまとめた
- パレットボタンを押してパレットを表示させるのをshowPaletteにまとめた
- パレットのユーザーログインをloginUserにまとめた
- spec分割したことで冗長になったdescribeを削除
- 実行順の影響で？失敗することが多かったのでspecの実行順を変更

## このPRで確認した事は何？
- [x] specがオールグリーン
