### PR TITLE
fix tabs process (use each EmojidexClientCategories/Indexes)

### DIFF
--- a/src/es6/emojidexPalette/components/tabs/category.js
+++ b/src/es6/emojidexPalette/components/tabs/category.js
@@ -1,3 +1,5 @@
+import EmojidexClientCategories from 'emojidex-client/src/es6/components/categories'
+
 export default class CategoryTab {
   constructor(palette, category) {
     this.palette = palette
@@ -5,43 +7,42 @@ export default class CategoryTab {
     this.sortType = 'score'
     this.categoryName = category.code
     this.tabList = $(`<li id='tab-${category.code}' data-code='${category.code}'><a href='#tab-content-${category.code}' data-toggle='pill'><i class='emjdx-${category.code}'></a></li>`) // eslint-disable-line no-undef
-    this.tabList.click(e => {
-      return this.setCategory($(e.currentTarget).data('code')) // eslint-disable-line no-undef
-    })
-
     this.tabContent = $(`<div class='tab-pane' id='tab-content-${category.code}'></div>`) // eslint-disable-line no-undef
+
+    new EmojidexClientCategories(palette.EC).then(ECC => {
+      this.ECC = ECC
+      this.tabList.click(e => {
+        return this.setCategory($(e.currentTarget).data('code')) // eslint-disable-line no-undef
+      })
+    })
   }
 
   setCategory(categoryName) {
-    if (this.tabData) {
-      this.palette.EC.Categories.calledData = this.tabData
-      return this.palette.EC.Categories.calledData
+    if (!this.initialized) {
+      return this.setCategoryTabContent(categoryName)
     }
-
-    return this.setCategoryTabContent(categoryName)
   }
 
   setCategoryTabContent(categoryName) {
     this.initialized = true
     this.categoryName = categoryName
-    return this.palette.EC.Categories.getEmoji(
+    return this.ECC.getEmoji(
       categoryName,
-      (resultEmoji, calledData) => {
-        this.tabData = calledData
+      resultEmoji => {
         this.tabContent.children().remove()
 
         const capitalizedCategory = this.palette.capitalize(this.categoryName)
         this.tabContent.append(`<div class="emojidex-category-name emjdx-${this.categoryName}">${capitalizedCategory}</div>`)
         this.tabContent.append(this.palette.setEmojiList('category', resultEmoji))
 
-        const curPage = this.palette.EC.Categories.meta.total_count === 0 ? 0 : this.palette.EC.Categories.curPage
-        let maxPage = Math.floor(this.palette.EC.Categories.meta.total_count / this.palette.EC.options.limit)
-        if (this.palette.EC.Categories.meta.total_count % this.palette.EC.options.limit > 0) {
+        const curPage = this.ECC.meta.total_count === 0 ? 0 : this.ECC.curPage
+        let maxPage = Math.floor(this.ECC.meta.total_count / this.palette.EC.options.limit)
+        if (this.ECC.meta.total_count % this.palette.EC.options.limit > 0) {
           maxPage++
         }
 
-        const prevFunc = () => this.palette.EC.Categories.prev()
-        const nextFunc = () => this.palette.EC.Categories.next()
+        const prevFunc = () => this.ECC.prev()
+        const nextFunc = () => this.ECC.next()
         const pagination = this.palette.getPagination('category', prevFunc, nextFunc, curPage, maxPage)
         pagination.append(this.palette.getSorting(this))
         return this.tabContent.append(pagination)

--- a/src/es6/emojidexPalette/components/tabs/index.js
+++ b/src/es6/emojidexPalette/components/tabs/index.js
@@ -1,5 +1,8 @@
+import EmojidexClientIndexes from 'emojidex-client/src/es6/components/indexes'
+
 export default class IndexTab {
   constructor(palette) {
+    this.ECI = new EmojidexClientIndexes(palette.EC)
     this.palette = palette
     this.initialized = false
     this.sortType = 'score'
@@ -10,22 +13,21 @@ export default class IndexTab {
 
   setTabContent() {
     this.initialized = true
-    return this.palette.EC.Indexes.index(
-      (resultEmoji, calledData) => {
-        this.tabData = calledData
+    return this.ECI.index(
+      resultEmoji => {
         this.tabContent.children().remove()
 
         this.tabContent.append('<div class="emojidex-category-name emjdx-all">Index</div>')
         this.tabContent.append(this.palette.setEmojiList('index', resultEmoji))
 
-        const curPage = this.palette.EC.Indexes.meta.total_count === 0 ? 0 : this.palette.EC.Indexes.curPage
-        let maxPage = Math.floor(this.palette.EC.Indexes.meta.total_count / this.palette.EC.options.limit)
-        if (this.palette.EC.Indexes.meta.total_count % this.palette.EC.options.limit > 0) {
+        const curPage = this.ECI.meta.total_count === 0 ? 0 : this.ECI.curPage
+        let maxPage = Math.floor(this.ECI.meta.total_count / this.palette.EC.options.limit)
+        if (this.ECI.meta.total_count % this.palette.EC.options.limit > 0) {
           maxPage++
         }
 
-        const prevFunc = () => this.palette.EC.Indexes.prev()
-        const nextFunc = () => this.palette.EC.Indexes.next()
+        const prevFunc = () => this.ECI.prev()
+        const nextFunc = () => this.ECI.next()
         const pagination = this.palette.getPagination('index', prevFunc, nextFunc, curPage, maxPage)
         pagination.append(this.palette.getSorting(this))
         return this.tabContent.append(pagination)


### PR DESCRIPTION
## 何でこの変更が必要なの？
インデックスと各カテゴリータブの絵文字表示にバグあったため

## このPRでやった事は何？
- 各カテゴリータブごとにEmojidexClietnCategoriesを作成して、個別にページ情報を持つようにした
- インデックスタブ内でEmojidexClietnIndexesを作成して、個別にページ情報を持つようにした
  - 個別にしないと、following/followersユーザー絵文字の情報とかぶるため
- 未使用コードの削除

## このPRではやらない事にした変更ってあった？
- 一般ユーザーのFavorite、HistoryのmaxPageの修正

## このPRで確認した事は何？
<!-- [必須] 下記以外に何か確認した事があれば、同じくチェック付きのリストで追記して下さい -->
- [x] specがオールグリーン
