### PR TITLE
[wip] Add threed

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ build
 .env
 tmp
 *.orig
+yarn-error.log

--- a/gulpfile.babel.js
+++ b/gulpfile.babel.js
@@ -103,7 +103,8 @@ gulp.task('copy',
 
 gulp.task('concat-spec', () => {
   const file = fs.readFileSync('build/spec/fixture/index.html', 'utf8')
-  fs.writeFileSync('build/spec/fixture/html.js', `var html = \`${file}\``)
+  const threedFile = fs.readFileSync('build/spec/fixture/threed.html', 'utf8')
+  fs.writeFileSync('build/spec/fixture/html.js', `var html = \`${file}\`; var threedHtml = \`${threedFile}\``)
   return gulp
     .src(['spec/helpers/method.js', 'build/spec/fixture/html.js'])
     .pipe(concat('html_in_method.js'))

--- a/package.json
+++ b/package.json
@@ -75,7 +75,7 @@
   },
   "dependencies": {
     "clipboard": "^1.5.5",
-    "core-js": "3",
+    "core-js": "^3.3.6",
     "emojidex-client": "https://github.com/emojidex/emojidex-web-client.git#add_threed",
     "jquery.caret": "^0.3.1",
     "textcomplete": "^0.17.1",

--- a/package.json
+++ b/package.json
@@ -76,7 +76,7 @@
   "dependencies": {
     "clipboard": "^1.5.5",
     "core-js": "3",
-    "emojidex-client": "^0.21.0",
+    "emojidex-client": "https://github.com/emojidex/emojidex-web-client.git#add_threed",
     "jquery.caret": "^0.3.1",
     "textcomplete": "^0.17.1",
     "textcomplete.contenteditable": "^0.1.1"

--- a/spec/emojidex-replace.js
+++ b/spec/emojidex-replace.js
@@ -1,13 +1,23 @@
 /* eslint-disable no-undef */
 describe('emojidexReplace', () => {
-  beforeEach(() => helperBefore())
-
-  afterAll(() => helperAfter())
+  afterEach(async () => await helperAfterForReplace())
 
   it('replace to emojidex-emoji', async done => {
+    await helperBefore()
+  
     $('body').emojidexReplace()
     await $('body').data().plugin_emojidexReplace
     expect($('.emojidex_replace')).toContainElement('img.emojidex-emoji')
+    done()
+  })
+
+  it('replace to emojidex-emoji (use 3D option)', async done => {
+    await helperBeforeForThreed()
+
+    $('body').emojidexReplace({ threed: true })
+    await $('body').data().plugin_emojidexReplace
+    await specTimer(5000)
+    expect($('.threed-container')).toContainElement('div.emojidex-scene')
     done()
   })
 })

--- a/spec/fixture/threed.pug
+++ b/spec/fixture/threed.pug
@@ -1,0 +1,3 @@
+html
+  body
+    .threed-container 💩 :poop: ⛩ :shinto_shrine: ☆ :star:

--- a/spec/helpers/method.js
+++ b/spec/helpers/method.js
@@ -23,6 +23,28 @@ function helperAfter() {
   })
 }
 
+function helperBeforeForThreed() {
+  return new Promise(resolve => {
+    if ($('#spec-wrap').length === 0) {
+      $('body').append(`<div id='spec-wrap'>${threedHtml}</div>`)
+      resolve()
+    } else {
+      resolve()
+    }
+  })
+}
+
+function helperAfterForReplace() {
+  return new Promise(async resolve => {
+    const replacer = await $('body').data().plugin_emojidexReplace
+    replacer.disconnect()
+    $('body').removeData().unbind()
+    window.emojidexReplacerOnce = false
+    $('#spec-wrap').remove()
+    resolve()
+  })
+}
+
 function specTimer(time) {
   return new Promise(resolve => {
     setTimeout(resolve, time)

--- a/src/es6/emojidexReplace/index.js
+++ b/src/es6/emojidexReplace/index.js
@@ -17,7 +17,8 @@ const defaults = {
   autoUpdate: true,
   selector: '*',
   ignore: 'script, noscript, canvas, img, style, iframe, input, textarea, pre, code',
-  ignoreContentEditable: true
+  ignoreContentEditable: true,
+  threed: false
 }
 
 export default class EmojidexReplace {
@@ -41,9 +42,11 @@ export default class EmojidexReplace {
 
   async replace() {
     if (this.options.autoUpdate) {
-      this.replacer = await new Observer(this).reloadEmoji()
+      this.replacer = new Observer(this)
+      await this.replacer.reloadEmoji()
     } else {
-      this.replacer = await new Replacer(this).loadEmoji()
+      this.replacer = new Replacer(this)
+      await this.replacer.loadEmoji()
     }
 
     return this.replacer

--- a/src/pug/threed_test.pug
+++ b/src/pug/threed_test.pug
@@ -1,0 +1,42 @@
+doctype html
+html
+  head
+    meta(charset="utf-8")
+    title emojidex-web 3D test
+    meta(content="" name="description")
+    meta(content="width=device-width" name="viewport")
+    link(href="css/document.css" rel="stylesheet")
+    link(href="css/emojidex.css" rel="stylesheet")
+    script(src="https://code.jquery.com/jquery-3.4.1.min.js")
+    script(src="https://stackpath.bootstrapcdn.com/bootstrap/3.4.1/js/bootstrap.min.js" integrity="sha384-aJ21OjlMXNL5UyIl/XNwTMqvzeRMZH2w8c5cRVpzpU8Y5bApTppSuUkhZXN0VxHd" crossorigin="anonymous")
+    script(src="js/emojidex.js")
+    style(type='text/css').
+      <!--
+        .text-wrap-20 {
+          display: flex;
+          font-size: 20px;
+        }
+        .text-wrap-30 {
+          display: flex;
+          font-size: 30px;
+        }
+        .text-wrap-40 {
+          display: flex;
+          font-size: 40px;
+        }
+      -->
+    script.
+      (function() {
+        $(document).ready((function(_this) {
+          return async function() {
+            $('body').emojidexReplace({ threed: true })
+            await $('body').data().plugin_emojidexReplace
+          };
+        })(this));
+      }).call(this);
+    
+  body
+    .text-wrap-20 💩aaa:poop:bbb💩aaa:poop:bbb💩aaa:poop:bbb
+    .text-wrap-30 ⛩ccc:shinto_shrine:ddd⛩ccc:shinto_shrine:ddd⛩ccc:shinto_shrine:ddd
+    .text-wrap-40 ☆eee:star:fff☆eee:star:fff☆eee:star:fff
+    .text-wrap-20 Not replaced💩⛩☆

--- a/src/sass/emojidex.scss
+++ b/src/sass/emojidex.scss
@@ -59,3 +59,13 @@ img.emojidex-emoji {
     }
   }
 }
+
+#emojidex-canvas {
+  position: absolute;
+  left: 0;
+}
+
+.emojidex-scene {
+  @include emoji;
+  top: 0em;
+}

--- a/webpack.config.babel.js
+++ b/webpack.config.babel.js
@@ -95,6 +95,11 @@ module.exports = (env, argv) => {
         inject: false
       }),
       new HtmlWebpackPlugin({
+        filename: 'threed_test.html',
+        template: 'src/pug/threed_test.pug',
+        inject: false
+      }),
+      new HtmlWebpackPlugin({
         filename: '../build/spec/fixture/index.html',
         template: 'spec/fixture/index.pug',
         inject: false

--- a/webpack.config.babel.js
+++ b/webpack.config.babel.js
@@ -104,6 +104,11 @@ module.exports = (env, argv) => {
         template: 'spec/fixture/index.pug',
         inject: false
       }),
+      new HtmlWebpackPlugin({
+        filename: '../build/spec/fixture/threed.html',
+        template: 'spec/fixture/threed.pug',
+        inject: false
+      }),
       new FixStyleOnlyEntriesPlugin({
         extensions: ['sass', 'scss']
       }),

--- a/yarn.lock
+++ b/yarn.lock
@@ -3075,15 +3075,17 @@ emoji-regex@^7.0.1:
   resolved "https://registry.yarnpkg.com/emoji-regex/-/emoji-regex-7.0.3.tgz#933a04052860c85e83c122479c4748a8e4c72156"
   integrity sha512-CwBLREIQ7LvYFB0WyRvwhq5N5qPhc6PMjD6bYggFlI5YyDgl+0vxq5VHbMOFqLg7hfWzmu8T5Z1QofhmTIhItA==
 
-emojidex-client@^0.21.0:
+"emojidex-client@https://github.com/emojidex/emojidex-web-client.git#add_threed":
   version "0.21.0"
-  resolved "https://registry.yarnpkg.com/emojidex-client/-/emojidex-client-0.21.0.tgz#2edb69e66b3ce55b4791fc4ffbfe40a8291fe96c"
-  integrity sha512-wPam5AXkwKNYue2hGWK8lydYf3f1XWLIOgMAm+Htm9QrBgHpqCwiKtHeX/f23xcuuy2Or0elMrQq5FEeSrkscA==
+  resolved "https://github.com/emojidex/emojidex-web-client.git#bf95f28e7e01f71a831dd833081b0e310552455d"
   dependencies:
     axios "^0.19.0"
     core-js "3"
     cross-storage "https://github.com/snowsunny/cross-storage.git"
     lodash "^4.17.14"
+    three "^0.109.0"
+    three-gltf-loader "^1.109.0"
+    three-orbitcontrols "^2.108.1"
 
 emojis-list@^2.0.0:
   version "2.1.0"
@@ -9285,6 +9287,21 @@ thenify@^3.1.1:
   integrity sha1-5p44obq+lpsBCCB5eLn2K4hgSDk=
   dependencies:
     any-promise "^1.0.0"
+
+three-gltf-loader@^1.109.0:
+  version "1.109.0"
+  resolved "https://registry.yarnpkg.com/three-gltf-loader/-/three-gltf-loader-1.109.0.tgz#64ebaa0d14704431c7b5f0be0938ad346a618d70"
+  integrity sha512-XI6ZG+DYEOjlfI0hv8qFvkw7mMDN6DhofzZta2/crh2eUBa6GgeLKWNxnMxuDkSyMCNRq6OfwibIbFT2MDdG6w==
+
+three-orbitcontrols@^2.108.1:
+  version "2.108.1"
+  resolved "https://registry.yarnpkg.com/three-orbitcontrols/-/three-orbitcontrols-2.108.1.tgz#3b7877390ee5cde151805646064de3c0be313474"
+  integrity sha512-822+Y0iI4Hi9iNC4Rnfp3vP68yHYdeNtpUHI+/43eihe7UzH+26uiP0ISWDH9/T4hNpGYt+JDxf5cGLV0TeZ8Q==
+
+three@^0.109.0:
+  version "0.109.0"
+  resolved "https://registry.yarnpkg.com/three/-/three-0.109.0.tgz#611c9ef860d10bd107695cead6c6abcd2422e5fd"
+  integrity sha512-XT99T3Hvgh2CEvwPdHYEunNE+clLK6KiT1U8En7YOgIqTUw4MrLeIc8zxQAJ6wbP8hhJaY5+Cff3jwBPpBa0gA==
 
 through2-filter@^3.0.0:
   version "3.0.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2432,6 +2432,11 @@ core-js@^2.4.0, core-js@^2.5.0:
   resolved "https://registry.yarnpkg.com/core-js/-/core-js-2.6.9.tgz#6b4b214620c834152e179323727fc19741b084f2"
   integrity sha512-HOpZf6eXmnl7la+cUdMnLvUxKNqLUzJvgIziQ0DiF3JwSImNphIqdGqzj6hIKyX04MmV0poclQ7+wjWvxQyR2A==
 
+core-js@^3.3.6:
+  version "3.3.6"
+  resolved "https://registry.yarnpkg.com/core-js/-/core-js-3.3.6.tgz#6ad1650323c441f45379e176ed175c0d021eac92"
+  integrity sha512-u4oM8SHwmDuh5mWZdDg9UwNVq5s1uqq6ZDLLIs07VY+VJU91i3h4f3K/pgFvtUQPGdeStrZ+odKyfyt4EnKHfA==
+
 core-util-is@1.0.2, core-util-is@~1.0.0:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/core-util-is/-/core-util-is-1.0.2.tgz#b5fd54220aa2bc5ab57aab7140c940754503c1a7"


### PR DESCRIPTION
## 何でこの変更が必要なの？
replacerで3D絵文字を表示したかった

## このPRでやった事は何？
- emojidexReplaceに3D絵文字を表示するかどうかのフラグを追加
- フラグがtrueの時、絵文字、絵文字コードを3Dに変換する
- specを追加

## このPRで確認した事は何？
<!-- [必須] 下記以外に何か確認した事があれば、同じくチェック付きのリストで追記して下さい -->
- [x] specがオールグリーン

## 何か伝達事項はある？
- リミットが16になっているけど、16個の絵文字を変換するわけではなく、16個のノードを変換します
  - 現時点の仕様がそうなっているので、必要なら別PRで修正します
- テスト用にemojidex-web-clientのadd_threedブランチを参照しています
  - client側がマージされてから修正
